### PR TITLE
feat: batch 3 — persona section, services layout, AI chatbot redesign, footer

### DIFF
--- a/client/src/components/shared/MarketingFooter.tsx
+++ b/client/src/components/shared/MarketingFooter.tsx
@@ -25,7 +25,7 @@ export default function MarketingFooter() {
               </span>
             </Link>
             <p className="text-sm text-[#596475] leading-relaxed max-w-xs">
-              Operational excellence platform for manufacturing. Real-time visibility, digital management, and continuous improvement.
+              Operational Excellence. One Digital Platform.
             </p>
             <p className="text-xs text-[#596475]">
               &copy; {currentYear} Oplytics Digital Ltd. All rights reserved.
@@ -125,7 +125,7 @@ export default function MarketingFooter() {
       <div className="border-t border-[#1E2738]/40">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col sm:flex-row items-center justify-between gap-2">
           <p className="text-xs text-[#596475]">
-            Built for operational excellence in manufacturing.
+            Operational Excellence. One Digital Platform.
           </p>
           <div className="flex items-center gap-4">
             <Link href="/privacy" className="text-xs text-[#596475] hover:text-[#8890A0] transition-colors">

--- a/client/src/components/shared/PersonaSection.tsx
+++ b/client/src/components/shared/PersonaSection.tsx
@@ -1,0 +1,180 @@
+/**
+ * Batch 3: "Who Is Oplytics For?" section
+ * Tab-based layout with 9 persona cards. OpEx/CI Leader is the champion (highlighted).
+ */
+import { useState } from 'react';
+import AnimateOnScroll from '@/components/shared/AnimateOnScroll';
+import {
+  Target, Briefcase, Building2, DollarSign, HardHat,
+  Shield, CheckCircle, Server, Wrench
+} from 'lucide-react';
+
+interface Persona {
+  id: string;
+  title: string;
+  icon: React.ReactNode;
+  description: string;
+  isChampion?: boolean;
+}
+
+const personas: Persona[] = [
+  {
+    id: 'opex',
+    title: 'OpEx / CI Leader',
+    icon: <Target className="w-5 h-5" />,
+    description: 'You live and breathe continuous improvement. But without the right digital infrastructure, your CI programmes rely on spreadsheets, manual updates and people remembering to follow the process. Oplytics is built for you — Policy Deployment, SQDCP Dashboards, OEE tracking and structured problem solving, all connected in one platform. Finally, a system that works the way CI should.',
+    isChampion: true,
+  },
+  {
+    id: 'ops-director',
+    title: 'Operations Director / President',
+    icon: <Briefcase className="w-5 h-5" />,
+    description: "You're accountable for performance across every site, every shift, every line. But your visibility depends on what people choose to report — and by the time it reaches you, it's already too late to act. Oplytics gives you a live operational picture from asset to enterprise, with AI-supported decision making that keeps your teams focused on what matters.",
+  },
+  {
+    id: 'ceo',
+    title: 'CEO',
+    icon: <Building2 className="w-5 h-5" />,
+    description: "You set the strategy. Oplytics deploys it. Policy Deployment cascades your objectives from enterprise level down to every site, area and asset — with live tracking of whether it's working. Your strategy doesn't stop at the boardroom door.",
+  },
+  {
+    id: 'cfo',
+    title: 'CFO / Finance',
+    icon: <DollarSign className="w-5 h-5" />,
+    description: "Every improvement initiative costs money before it saves it. Oplytics makes the ROI visible — real-time OEE data, structured action tracking, and policy deployment that connects strategy to shop floor execution. You'll see where the losses are, what's being done about them, and whether it's working.",
+  },
+  {
+    id: 'plant-manager',
+    title: 'Plant Managers & Supervisors',
+    icon: <HardHat className="w-5 h-5" />,
+    description: "You run the floor. You know every problem before it gets escalated — but you're spending your day in meetings, chasing updates and firefighting. Oplytics puts structured improvement into the hands of your teams, so problems get contained, root causes get found, and actions get closed. Less firefighting. More leading.",
+  },
+  {
+    id: 'hse',
+    title: 'HSE Leader',
+    icon: <Shield className="w-5 h-5" />,
+    description: "Near misses don't become incidents if your teams have the tools to act fast. Oplytics gives HSE leaders structured Stop Work Authority, LOTO workflows, and safety action tracking — all integrated into the same platform your operations teams use every day.",
+  },
+  {
+    id: 'quality',
+    title: 'Quality Leader',
+    icon: <CheckCircle className="w-5 h-5" />,
+    description: "Quality issues rarely have one cause. Oplytics gives your team 5 Whys, Fishbone, and 8D methodology built into every action — with containment approval routed to you before work continues. Structured. Traceable. Auditable.",
+  },
+  {
+    id: 'it',
+    title: 'IT',
+    icon: <Server className="w-5 h-5" />,
+    description: "You're asked to connect systems that were never designed to talk to each other. Oplytics gives you a single integration hub — OplyticsConnect — that manages data feeds in and out of the platform. Standard APIs, clear architecture, enterprise security. Something you can actually support.",
+  },
+  {
+    id: 'operator',
+    title: 'Asset Operators',
+    icon: <Wrench className="w-5 h-5" />,
+    description: "You're closest to the problem. Oplytics gives you the tools to report it, contain it, and fix it — without waiting for someone else to notice. Simple data entry, clear actions, and AI guidance when you need it.",
+  },
+];
+
+export default function PersonaSection() {
+  const [activeId, setActiveId] = useState('opex');
+  const active = personas.find(p => p.id === activeId) || personas[0];
+
+  return (
+    <section className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 border-y border-[#1E2738]/40" role="region" aria-label="Who is Oplytics for">
+      <div className="max-w-6xl mx-auto">
+        <AnimateOnScroll variant="slide-up" className="text-center mb-10 sm:mb-14">
+          <span className="section-label text-[#F59E0B] mb-3 block">Convincing Your Colleagues</span>
+          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white" style={{ fontFamily: 'Montserrat' }}>
+            Who Is Oplytics For?
+          </h2>
+          <p className="text-sm sm:text-base text-[#8890A0] mt-4 max-w-2xl mx-auto">
+            Every role in your organisation benefits from a connected operational excellence platform. Here is how Oplytics speaks to each.
+          </p>
+        </AnimateOnScroll>
+
+        {/* Tab Navigation */}
+        <div className="flex flex-wrap justify-center gap-2 mb-8 sm:mb-10">
+          {personas.map(persona => (
+            <button
+              key={persona.id}
+              onClick={() => setActiveId(persona.id)}
+              className={`
+                inline-flex items-center gap-2 px-3 py-2 sm:px-4 sm:py-2.5 rounded-lg text-xs sm:text-sm font-medium transition-all duration-200
+                ${activeId === persona.id
+                  ? persona.isChampion
+                    ? 'bg-[#F59E0B]/15 text-[#F59E0B] border border-[#F59E0B]/40 shadow-[0_0_12px_rgba(245,158,11,0.15)]'
+                    : 'bg-[#8C34E9]/15 text-[#C084FC] border border-[#8C34E9]/40'
+                  : 'text-[#8890A0] border border-[#1E2738] hover:border-[#8C34E9]/30 hover:text-white bg-[#0D1220]/60'
+                }
+              `}
+            >
+              {persona.icon}
+              <span className="hidden sm:inline">{persona.title}</span>
+              <span className="sm:hidden">{persona.title.split('/')[0].split('&')[0].trim()}</span>
+              {persona.isChampion && activeId === persona.id && (
+                <span className="text-[9px] font-bold tracking-wider uppercase px-1.5 py-0.5 rounded bg-[#F59E0B]/20 text-[#F59E0B] ml-1 hidden sm:inline">
+                  Champion
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* Active Persona Card */}
+        <AnimateOnScroll variant="fade-in" key={active.id}>
+          <div
+            className={`
+              relative max-w-3xl mx-auto p-6 sm:p-8 rounded-xl border transition-all duration-300
+              ${active.isChampion
+                ? 'border-[#F59E0B]/30 bg-gradient-to-br from-[#F59E0B]/5 via-[#0D1220] to-[#0D1220]'
+                : 'border-[#1E2738] bg-[#0D1220]'
+              }
+            `}
+            style={{
+              boxShadow: active.isChampion
+                ? '0 0 30px rgba(245,158,11,0.08), 0 4px 20px rgba(0,0,0,0.3)'
+                : '0 4px 20px rgba(0,0,0,0.3)',
+            }}
+          >
+            {/* Champion badge */}
+            {active.isChampion && (
+              <div className="absolute -top-3 left-6 sm:left-8">
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-bold tracking-wider uppercase bg-[#F59E0B] text-[#0D1220]">
+                  <Target className="w-3 h-3" />
+                  Champion Role
+                </span>
+              </div>
+            )}
+
+            <div className="flex items-start gap-4 sm:gap-5">
+              <div
+                className={`
+                  w-12 h-12 sm:w-14 sm:h-14 rounded-lg flex items-center justify-center flex-shrink-0
+                  ${active.isChampion
+                    ? 'bg-[#F59E0B]/10 border border-[#F59E0B]/20'
+                    : 'bg-[#8C34E9]/10 border border-[#8C34E9]/20'
+                  }
+                `}
+              >
+                <div className={active.isChampion ? 'text-[#F59E0B]' : 'text-[#C084FC]'}>
+                  {active.icon}
+                </div>
+              </div>
+              <div className="flex-1">
+                <h3
+                  className={`text-lg sm:text-xl font-bold mb-3 ${active.isChampion ? 'text-[#F59E0B]' : 'text-white'}`}
+                  style={{ fontFamily: 'Montserrat' }}
+                >
+                  {active.title}
+                </h3>
+                <p className="text-sm sm:text-base text-[#A0A8B8] leading-relaxed">
+                  {active.description}
+                </p>
+              </div>
+            </div>
+          </div>
+        </AnimateOnScroll>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/shared/SimpleChatbotWidget.tsx
+++ b/client/src/components/shared/SimpleChatbotWidget.tsx
@@ -1,35 +1,59 @@
 /**
- * TASK-08: SimpleChatbotWidget Component (Minimal Link-Based)
- * Design: "Neon Operations" — floating purple button with quick action links
- *
- * Floating button in bottom-right corner with pulse animation for visibility.
- * Expands to show 4 quick action links.
- * No backend or LLM integration — placeholder for future AI chatbot.
+ * Batch 3: AI Support Engineer Widget (Redesigned)
+ * Larger, more prominent floating widget with:
+ * - "AI Support Engineer" label
+ * - AI theme colour (#1DB8CE) matching the "AI-Powered Platform" badge
+ * - Mock text input (no backend yet)
+ * - Avatar icon
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { X, Sparkles, Send, ArrowRight } from 'lucide-react';
 import { Link } from 'wouter';
-import { MessageCircle, X, Calendar, DollarSign, Mail, HelpCircle } from 'lucide-react';
 
-const quickActions = [
-  { label: 'Book a Demo', href: '/contact', icon: Calendar, description: 'Schedule a walkthrough' },
-  { label: 'View Pricing', href: '/pricing', icon: DollarSign, description: 'See our plans' },
-  { label: 'Contact Sales', href: '/contact', icon: Mail, description: 'Talk to our team' },
-  { label: 'What is Oplytics?', href: '/', icon: HelpCircle, description: 'Learn about us' },
+const suggestedQuestions = [
+  'What is Policy Deployment?',
+  'How does OEE Manager work?',
+  'Can Oplytics integrate with our ERP?',
+  'What does the AI Support Engineer do?',
 ];
 
 export default function SimpleChatbotWidget() {
   const [open, setOpen] = useState(false);
   const [showPulse, setShowPulse] = useState(true);
+  const [inputValue, setInputValue] = useState('');
+  const [messages, setMessages] = useState<{ role: 'user' | 'ai'; text: string }[]>([]);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Stop pulsing after 10 seconds or when opened
   useEffect(() => {
     const timer = setTimeout(() => setShowPulse(false), 10000);
     return () => clearTimeout(timer);
   }, []);
 
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
   const handleToggle = () => {
     setOpen(!open);
     setShowPulse(false);
+  };
+
+  const handleSend = (text?: string) => {
+    const question = text || inputValue.trim();
+    if (!question) return;
+    setMessages(prev => [
+      ...prev,
+      { role: 'user', text: question },
+      { role: 'ai', text: 'Thanks for your question! The AI Support Engineer is currently being trained on the Oplytics platform. In the meantime, our team would love to help — get in touch via the Contact page.' },
+    ]);
+    setInputValue('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
   };
 
   return (
@@ -37,72 +61,152 @@ export default function SimpleChatbotWidget() {
       {/* Expanded Panel */}
       {open && (
         <div
-          className="absolute bottom-16 right-0 w-72 bg-[#0D1220] border border-[#1E2738] rounded-lg overflow-hidden mb-2"
-          style={{ boxShadow: '0 8px 40px rgba(0,0,0,0.5), 0 0 20px rgba(140,52,233,0.15)' }}
+          className="absolute bottom-20 right-0 w-80 sm:w-96 bg-[#0D1220] border border-[#1DB8CE]/20 rounded-xl overflow-hidden mb-2"
+          style={{ boxShadow: '0 8px 40px rgba(0,0,0,0.5), 0 0 30px rgba(29,184,206,0.12)' }}
         >
-          <div className="p-4 border-b border-[#1E2738]" style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}>
+          {/* Header */}
+          <div className="p-4 border-b border-[#1E2738]" style={{ background: 'linear-gradient(135deg, #1DB8CE 0%, #0E8A9A 100%)' }}>
             <div className="flex items-center justify-between">
-              <div>
-                <h4 className="text-sm font-bold text-white" style={{ fontFamily: 'Montserrat' }}>
-                  How can we help?
-                </h4>
-                <p className="text-xs text-white/70">Quick links to get started</p>
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-white/15 flex items-center justify-center border border-white/20">
+                  <Sparkles className="w-5 h-5 text-white" />
+                </div>
+                <div>
+                  <h4 className="text-sm font-bold text-white" style={{ fontFamily: 'Montserrat' }}>
+                    AI Support Engineer
+                  </h4>
+                  <div className="flex items-center gap-1.5">
+                    <span className="relative flex h-1.5 w-1.5">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-[#22C55E] opacity-75" />
+                      <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-[#22C55E]" />
+                    </span>
+                    <span className="text-[10px] text-white/70">Training in progress</span>
+                  </div>
+                </div>
               </div>
               <button
                 onClick={() => setOpen(false)}
-                className="text-white/70 hover:text-white transition-colors"
+                className="text-white/70 hover:text-white transition-colors p-1"
               >
                 <X className="w-4 h-4" />
               </button>
             </div>
           </div>
 
-          <div className="p-2">
-            {quickActions.map((action, i) => (
-              <Link
-                key={i}
-                href={action.href}
-                onClick={() => setOpen(false)}
-                className="flex items-center gap-3 px-3 py-2.5 rounded-md hover:bg-[#1E2738]/60 transition-colors group"
-              >
-                <div className="w-8 h-8 rounded-md bg-[#8C34E9]/10 flex items-center justify-center shrink-0 group-hover:bg-[#8C34E9]/20 transition-colors">
-                  <action.icon className="w-4 h-4 text-[#C084FC]" />
+          {/* Messages Area */}
+          <div className="h-64 overflow-y-auto p-4 space-y-3">
+            {messages.length === 0 ? (
+              <>
+                {/* Welcome message */}
+                <div className="flex items-start gap-2.5">
+                  <div className="w-7 h-7 rounded-full bg-[#1DB8CE]/15 flex items-center justify-center flex-shrink-0 border border-[#1DB8CE]/20">
+                    <Sparkles className="w-3.5 h-3.5 text-[#1DB8CE]" />
+                  </div>
+                  <div className="bg-[#1E2738]/60 rounded-lg rounded-tl-none px-3 py-2.5 max-w-[85%]">
+                    <p className="text-xs text-[#A0A8B8] leading-relaxed">
+                      Hello! I'm the Oplytics AI Support Engineer. I'm currently being trained on the full platform. Try asking a question below, or speak to our team directly.
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <div className="text-sm font-medium text-white">{action.label}</div>
-                  <div className="text-xs text-[#596475]">{action.description}</div>
+
+                {/* Suggested questions */}
+                <div className="space-y-1.5 pt-2">
+                  <p className="text-[10px] font-medium text-[#596475] uppercase tracking-wider px-1">Suggested questions</p>
+                  {suggestedQuestions.map((q, i) => (
+                    <button
+                      key={i}
+                      onClick={() => handleSend(q)}
+                      className="w-full text-left px-3 py-2 rounded-lg border border-[#1DB8CE]/10 bg-[#1DB8CE]/5 hover:bg-[#1DB8CE]/10 hover:border-[#1DB8CE]/25 transition-all text-xs text-[#A0A8B8] hover:text-white flex items-center justify-between group"
+                    >
+                      <span>{q}</span>
+                      <ArrowRight className="w-3 h-3 text-[#1DB8CE] opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </button>
+                  ))}
                 </div>
-              </Link>
-            ))}
+              </>
+            ) : (
+              <>
+                {messages.map((msg, i) => (
+                  <div key={i} className={`flex items-start gap-2.5 ${msg.role === 'user' ? 'flex-row-reverse' : ''}`}>
+                    {msg.role === 'ai' && (
+                      <div className="w-7 h-7 rounded-full bg-[#1DB8CE]/15 flex items-center justify-center flex-shrink-0 border border-[#1DB8CE]/20">
+                        <Sparkles className="w-3.5 h-3.5 text-[#1DB8CE]" />
+                      </div>
+                    )}
+                    <div
+                      className={`rounded-lg px-3 py-2.5 max-w-[85%] ${
+                        msg.role === 'user'
+                          ? 'bg-[#1DB8CE]/15 rounded-tr-none border border-[#1DB8CE]/20'
+                          : 'bg-[#1E2738]/60 rounded-tl-none'
+                      }`}
+                    >
+                      <p className="text-xs text-[#A0A8B8] leading-relaxed">{msg.text}</p>
+                    </div>
+                  </div>
+                ))}
+                <div ref={messagesEndRef} />
+              </>
+            )}
           </div>
 
-          <div className="px-4 py-3 border-t border-[#1E2738] bg-[#080C16]">
-            <p className="text-[10px] text-[#596475] text-center">
-              AI-powered assistant coming soon
-            </p>
+          {/* Input Area */}
+          <div className="p-3 border-t border-[#1E2738]">
+            <div className="flex items-center gap-2 bg-[#080C16] rounded-lg border border-[#1E2738] focus-within:border-[#1DB8CE]/40 transition-colors">
+              <input
+                type="text"
+                value={inputValue}
+                onChange={e => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Ask a question..."
+                className="flex-1 bg-transparent text-sm text-white placeholder-[#596475] px-3 py-2.5 outline-none"
+              />
+              <button
+                onClick={() => handleSend()}
+                disabled={!inputValue.trim()}
+                className="p-2 mr-1 rounded-md bg-[#1DB8CE]/15 text-[#1DB8CE] hover:bg-[#1DB8CE]/25 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+              >
+                <Send className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="mt-2 text-center">
+              <Link
+                href="/contact"
+                onClick={() => setOpen(false)}
+                className="text-[10px] text-[#1DB8CE] hover:text-[#1DB8CE]/80 transition-colors"
+              >
+                Prefer to speak to a human? Contact us
+              </Link>
+            </div>
           </div>
         </div>
       )}
 
-      {/* Floating Button */}
+      {/* Floating Button — larger with label */}
       <div className="relative">
-        {/* Pulse ring for visibility */}
         {showPulse && !open && (
-          <span className="absolute inset-0 rounded-full animate-ping opacity-30" style={{ background: '#8C34E9' }} />
+          <span className="absolute inset-0 rounded-full animate-ping opacity-20" style={{ background: '#1DB8CE' }} />
         )}
         <button
           onClick={handleToggle}
-          className="relative w-14 h-14 rounded-full flex items-center justify-center text-white transition-all duration-300 hover:scale-110"
+          className="relative flex items-center gap-2.5 rounded-full text-white transition-all duration-300 hover:scale-105"
           style={{
-            background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)',
-            boxShadow: '0 4px 20px rgba(140,52,233,0.4), 0 0 40px rgba(140,52,233,0.15)',
+            background: 'linear-gradient(135deg, #1DB8CE 0%, #0E8A9A 100%)',
+            boxShadow: '0 4px 24px rgba(29,184,206,0.35), 0 0 40px rgba(29,184,206,0.12)',
+            padding: open ? '14px' : '14px 20px 14px 16px',
           }}
-          aria-label="Open help menu"
+          aria-label="Open AI Support Engineer"
         >
           {open ? (
             <X className="w-6 h-6" />
           ) : (
-            <MessageCircle className="w-6 h-6" />
+            <>
+              <div className="w-8 h-8 rounded-full bg-white/15 flex items-center justify-center border border-white/20">
+                <Sparkles className="w-4 h-4" />
+              </div>
+              <span className="text-sm font-semibold hidden sm:inline" style={{ fontFamily: 'Montserrat' }}>
+                AI Support Engineer
+              </span>
+            </>
           )}
         </button>
       </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import MarketingLayout from '@/components/shared/MarketingLayout';
 import HeroSection from '@/components/shared/HeroSection';
 import ServiceCard from '@/components/shared/ServiceCard';
 import FeatureGrid from '@/components/shared/FeatureGrid';
+import PersonaSection from '@/components/shared/PersonaSection';
 import SEOHead from '@/components/shared/SEOHead';
 import AnimateOnScroll, { StaggerContainer } from '@/components/shared/AnimateOnScroll';
 import { coreServices, hubServices, liveServices } from '@/config/services';
@@ -113,7 +114,13 @@ export default function Home() {
             </p>
           </AnimateOnScroll>
 
-          {/* Core Services */}
+          {/* Core Platform */}
+          <div className="flex items-center gap-4 mb-6">
+            <span className="text-[9px] sm:text-[10px] font-bold tracking-[0.2em] uppercase text-[#8C34E9] whitespace-nowrap">
+              Core Platform
+            </span>
+            <div className="flex-1 h-px bg-gradient-to-r from-[#8C34E9]/20 to-transparent" />
+          </div>
           <StaggerContainer className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 sm:gap-6" variant="slide-up" staggerDelay={0.08}>
             {coreServices.map(service => (
               <ServiceCard key={service.id} service={service} />
@@ -160,7 +167,7 @@ export default function Home() {
           </AnimateOnScroll>
           <StaggerContainer className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 text-left" variant="slide-up" staggerDelay={0.1}>
             {[
-              { title: 'Predictive Analytics', desc: 'AI forecasts equipment failures, quality issues, and safety risks before they happen.' },
+              { title: 'Smart Guided CI Coaching', desc: 'Our AI Support Engineer coaches your teams through standard CI processes — from 5 Whys to corrective action planning — in real time.' },
               { title: 'Smart Automation', desc: 'Automatic loss classification, action prioritisation, and compliance gap detection.' },
               { title: 'Natural Language Insights', desc: 'AI generates plain-English summaries of trends, anomalies, and recommended actions.' },
             ].map((item, i) => (
@@ -184,6 +191,9 @@ export default function Home() {
         sectionLabel="Why Oplytics"
         sectionTitle="Built Different. Built Better."
       />
+
+      {/* Who Is Oplytics For? */}
+      <PersonaSection />
 
       {/* Bottom CTA */}
       <section className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8" role="region" aria-label="Call to action">


### PR DESCRIPTION
## Batch 3 — Design & Architecture Changes

### Changes
1. **NEW: 'Who Is Oplytics For?' section** — 9 persona cards in a tab-based layout after 'Why Oplytics'. OpEx/CI Leader highlighted as Champion with gold accent.
2. **Services grid restructured** — 'Core Platform' label added above the 5 core services, 'Specialist Hubs' separator retained below.
3. **AI section updated** — Removed 'Predictive Analytics' card (predictive maintenance reference), replaced with 'Smart Guided CI Coaching via our AI Support Engineer'. AI theme colour (#1DB8CE) consistent throughout.
4. **AI Chatbot redesigned** — Larger floating button with avatar icon and 'AI Support Engineer' label. AI theme colour (#1DB8CE). Mock text input with suggested questions. Welcome message and placeholder responses.
5. **Footer updated** — Left text synced to hero: 'Operational Excellence. One Digital Platform.' Copyright: '© 2026 Oplytics Digital Ltd. All rights reserved.'

### Files changed
- `client/src/components/shared/PersonaSection.tsx` (new)
- `client/src/components/shared/SimpleChatbotWidget.tsx` (rewritten)
- `client/src/components/shared/MarketingFooter.tsx` (edited)
- `client/src/pages/Home.tsx` (edited)

### Not changed
- Demo components
- Solution page content
- Batch 2 copy
- Routing / backend