### PR TITLE
fix: correct slug keys in demoComponents map

### DIFF
--- a/client/src/components/demos/index.ts
+++ b/client/src/components/demos/index.ts
@@ -17,9 +17,9 @@ export const CertificationManagerDemo = lazy(() => import('./CertificationManage
 /** Map from service slug → lazy demo component */
 export const demoComponents: Record<string, React.LazyExoticComponent<React.ComponentType>> = {
   'policy-deployment': PolicyDeploymentDemo,
-  'sqdcp-hub': SQDCPHubDemo,
+  'sqdcp': SQDCPHubDemo,
   'oee-manager': OEEManagerDemo,
-  'smartconnect': ConnectDemo,
+  'connect': ConnectDemo,
   'action-manager': ActionManagerDemo,
   'quality-manager': QualityManagerDemo,
   'safety-manager': SafetyManagerDemo,


### PR DESCRIPTION
## Summary

Corrects two mismatched slug keys in the `demoComponents` map (`client/src/components/demos/index.ts`) so that the SQDCP Dashboard and OplyticsConnect animated demos render correctly on their solution pages.

## Changes

- Changed `'sqdcp-hub'` → `'sqdcp'` to match the SQDCP Dashboard slug in `services.ts`
- Changed `'smartconnect'` → `'connect'` to match the OplyticsConnect slug in `services.ts`

## Testing

- Verified the slug values match `services.ts` (`sqdcp` and `connect`)
- No other files affected — only the lookup keys changed
- All 8 demo components remain correctly imported