### PR TITLE
fix: replace SQDCP demo image with real dashboard screenshot

### DIFF
--- a/client/src/config/services.ts
+++ b/client/src/config/services.ts
@@ -104,7 +104,7 @@ export const services: ServiceConfig[] = [
     icon: 'LayoutGrid',
     accentColor: '#1DB8CE',
     category: 'core',
-    demoImage: 'https://d2xsxph8kpxj0f.cloudfront.net/310419663031899852/TqfjMS5mXpLDBG5ze8gzfz/demo-sqdcp-9ZfUnEfV9W4Nit7Y6epdho.webp',
+    demoImage: 'https://d2xsxph8kpxj0f.cloudfront.net/310419663031899852/TqfjMS5mXpLDBG5ze8gzfz/sqdcp-dashboard-real_bcc775e0.png',
     problem: 'Physical whiteboards are static, illegible from a distance, and impossible to aggregate across sites. Tier meetings rely on outdated data, actions get lost on sticky notes, and management has no visibility into daily performance without walking the floor.',
     howItWorks: [
       { step: 1, title: 'Configure Your Boards', description: 'Set up digital SQDCP boards for each team, cell, or value stream. Define metrics, targets, and escalation rules.' },


### PR DESCRIPTION
## Summary

Replaces the AI-generated placeholder image for the SQDCP Dashboard solution page with a real screenshot taken from sqdcp.oplytics.digital showing live Vita Group / Vita Mattress Middleton data.

## Changes

- Updated `demoImage` URL in `services.ts` for the SQDCP Dashboard service
- Old: manufactured AI-generated demo image
- New: real screenshot showing all 5 SQDCP categories (Safety, Quality, Delivery, Cost, People) with green ring gauges, 'On Target' status, 11/11 data coverage
- The 'Try It Live' hover overlay on SolutionPage is unchanged

## Testing

- Verified the new CDN URL is accessible and loads correctly
- SolutionPage demoImage rendering logic and hover overlay are untouched
- Only one line changed in services.ts