### PR TITLE
fix: remove browser mockup frame for SQDCP static screenshot demo

### DIFF
--- a/client/src/pages/SolutionPage.tsx
+++ b/client/src/pages/SolutionPage.tsx
@@ -179,24 +179,16 @@ export default function SolutionPage() {
             </p>
           </div>
 
-          <div className="relative rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden">
-            <div className="flex items-center gap-2 px-4 py-3 border-b border-[#1E2738] bg-[#080C16]">
-              <div className="flex gap-1.5">
-                <div className="w-3 h-3 rounded-full bg-[#EF4444]/60" />
-                <div className="w-3 h-3 rounded-full bg-[#F59E0B]/60" />
-                <div className="w-3 h-3 rounded-full bg-[#22C55E]/60" />
-              </div>
-              <div className="flex-1 mx-4">
-                <div className="bg-[#1E2738] rounded-md px-3 py-1.5 text-xs text-[#596475] font-mono">
-                  {service.subdomain || `${service.slug}.oplytics.digital`}
-                </div>
-              </div>
-            </div>
+          {/* Slugs whose DemoComponent is a static screenshot (no browser mockup frame) */}
+          {(() => {
+            const staticScreenshotSlugs = ['sqdcp'];
+            const isStatic = staticScreenshotSlugs.includes(service.slug);
+            const DemoComponent = demoComponents[service.slug];
 
-            {(() => {
-              const DemoComponent = demoComponents[service.slug];
-              if (DemoComponent) {
-                return (
+            /* ── Static screenshot path: image + "Try It Live" overlay, no browser chrome ── */
+            if (isStatic && DemoComponent) {
+              return (
+                <div className="relative rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden group">
                   <Suspense fallback={
                     <div className="aspect-video flex items-center justify-center">
                       <div className="animate-pulse text-[#596475] text-sm">Loading demo...</div>
@@ -204,53 +196,8 @@ export default function SolutionPage() {
                   }>
                     <DemoComponent />
                   </Suspense>
-                );
-              }
-              if (service.demoImage) {
-                return (
-                  <div className="relative group">
-                    <img
-                      src={service.demoImage}
-                      alt={`${service.name} dashboard screenshot`}
-                      className="w-full h-auto"
-                      loading="lazy"
-                    />
-                    <div className="absolute inset-0 bg-[#080C16]/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col items-center justify-center">
-                      <div className="w-16 h-16 rounded-full bg-[#8C34E9]/20 flex items-center justify-center mb-4 border border-[#8C34E9]/30">
-                        {service.status === 'live' ? (
-                          <Play className="w-7 h-7 text-[#C084FC] ml-1" />
-                        ) : (
-                          <Monitor className="w-7 h-7 text-[#C084FC]" />
-                        )}
-                      </div>
-                      <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
-                        {service.status === 'live' ? 'Try It Live' : 'Preview Coming Soon'}
-                      </h3>
-                      <p className="text-sm text-[#A0A8B8] max-w-md mx-auto mb-4 text-center px-4">
-                        {service.status === 'live'
-                          ? `Launch a guided walkthrough of ${service.name} with sample manufacturing data.`
-                          : `Register your interest to be notified when ${service.name} launches.`}
-                      </p>
-                      <Link
-                        href="/contact"
-                        className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
-                        style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
-                      >
-                        {service.status === 'live' ? 'Request Live Demo' : 'Register Interest'}
-                        <ArrowRight className="w-4 h-4" />
-                      </Link>
-                    </div>
-                  </div>
-                );
-              }
-              return (
-                <div className="aspect-video flex flex-col items-center justify-center p-8 text-center relative">
-                  <div className="absolute inset-0 opacity-5" style={{
-                    backgroundImage: 'linear-gradient(#8C34E9 1px, transparent 1px), linear-gradient(90deg, #8C34E9 1px, transparent 1px)',
-                    backgroundSize: '40px 40px',
-                  }} />
-                  <div className="relative z-10">
-                    <div className="w-16 h-16 rounded-full bg-[#8C34E9]/10 flex items-center justify-center mx-auto mb-6 border border-[#8C34E9]/20">
+                  <div className="absolute inset-0 bg-[#080C16]/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col items-center justify-center">
+                    <div className="w-16 h-16 rounded-full bg-[#8C34E9]/20 flex items-center justify-center mb-4 border border-[#8C34E9]/30">
                       {service.status === 'live' ? (
                         <Play className="w-7 h-7 text-[#C084FC] ml-1" />
                       ) : (
@@ -258,26 +205,128 @@ export default function SolutionPage() {
                       )}
                     </div>
                     <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
-                      {service.status === 'live' ? 'Interactive Demo' : 'Preview Coming Soon'}
+                      {service.status === 'live' ? 'Try It Live' : 'Preview Coming Soon'}
                     </h3>
-                    <p className="text-sm text-[#8890A0] max-w-md mx-auto mb-6">
+                    <p className="text-sm text-[#A0A8B8] max-w-md mx-auto mb-4 text-center px-4">
                       {service.status === 'live'
-                        ? `Click below to launch a guided walkthrough of ${service.name} with sample manufacturing data.`
-                        : `We are building the ${service.name} demo experience. Register your interest to be notified when it is ready.`}
+                        ? `Launch a guided walkthrough of ${service.name} with sample manufacturing data.`
+                        : `Register your interest to be notified when ${service.name} launches.`}
                     </p>
                     <Link
                       href="/contact"
                       className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
                       style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
                     >
-                      {service.status === 'live' ? 'Launch Demo' : 'Request Preview'}
+                      {service.status === 'live' ? 'Request Live Demo' : 'Register Interest'}
                       <ArrowRight className="w-4 h-4" />
                     </Link>
                   </div>
                 </div>
               );
-            })()}
-          </div>
+            }
+
+            /* ── Default path: browser mockup frame wrapping animated demos / demoImage / placeholder ── */
+            return (
+              <div className="relative rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden">
+                <div className="flex items-center gap-2 px-4 py-3 border-b border-[#1E2738] bg-[#080C16]">
+                  <div className="flex gap-1.5">
+                    <div className="w-3 h-3 rounded-full bg-[#EF4444]/60" />
+                    <div className="w-3 h-3 rounded-full bg-[#F59E0B]/60" />
+                    <div className="w-3 h-3 rounded-full bg-[#22C55E]/60" />
+                  </div>
+                  <div className="flex-1 mx-4">
+                    <div className="bg-[#1E2738] rounded-md px-3 py-1.5 text-xs text-[#596475] font-mono">
+                      {service.subdomain || `${service.slug}.oplytics.digital`}
+                    </div>
+                  </div>
+                </div>
+
+                {(() => {
+                  if (DemoComponent) {
+                    return (
+                      <Suspense fallback={
+                        <div className="aspect-video flex items-center justify-center">
+                          <div className="animate-pulse text-[#596475] text-sm">Loading demo...</div>
+                        </div>
+                      }>
+                        <DemoComponent />
+                      </Suspense>
+                    );
+                  }
+                  if (service.demoImage) {
+                    return (
+                      <div className="relative group">
+                        <img
+                          src={service.demoImage}
+                          alt={`${service.name} dashboard screenshot`}
+                          className="w-full h-auto"
+                          loading="lazy"
+                        />
+                        <div className="absolute inset-0 bg-[#080C16]/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col items-center justify-center">
+                          <div className="w-16 h-16 rounded-full bg-[#8C34E9]/20 flex items-center justify-center mb-4 border border-[#8C34E9]/30">
+                            {service.status === 'live' ? (
+                              <Play className="w-7 h-7 text-[#C084FC] ml-1" />
+                            ) : (
+                              <Monitor className="w-7 h-7 text-[#C084FC]" />
+                            )}
+                          </div>
+                          <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
+                            {service.status === 'live' ? 'Try It Live' : 'Preview Coming Soon'}
+                          </h3>
+                          <p className="text-sm text-[#A0A8B8] max-w-md mx-auto mb-4 text-center px-4">
+                            {service.status === 'live'
+                              ? `Launch a guided walkthrough of ${service.name} with sample manufacturing data.`
+                              : `Register your interest to be notified when ${service.name} launches.`}
+                          </p>
+                          <Link
+                            href="/contact"
+                            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
+                            style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
+                          >
+                            {service.status === 'live' ? 'Request Live Demo' : 'Register Interest'}
+                            <ArrowRight className="w-4 h-4" />
+                          </Link>
+                        </div>
+                      </div>
+                    );
+                  }
+                  return (
+                    <div className="aspect-video flex flex-col items-center justify-center p-8 text-center relative">
+                      <div className="absolute inset-0 opacity-5" style={{
+                        backgroundImage: 'linear-gradient(#8C34E9 1px, transparent 1px), linear-gradient(90deg, #8C34E9 1px, transparent 1px)',
+                        backgroundSize: '40px 40px',
+                      }} />
+                      <div className="relative z-10">
+                        <div className="w-16 h-16 rounded-full bg-[#8C34E9]/10 flex items-center justify-center mx-auto mb-6 border border-[#8C34E9]/20">
+                          {service.status === 'live' ? (
+                            <Play className="w-7 h-7 text-[#C084FC] ml-1" />
+                          ) : (
+                            <Monitor className="w-7 h-7 text-[#C084FC]" />
+                          )}
+                        </div>
+                        <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
+                          {service.status === 'live' ? 'Interactive Demo' : 'Preview Coming Soon'}
+                        </h3>
+                        <p className="text-sm text-[#8890A0] max-w-md mx-auto mb-6">
+                          {service.status === 'live'
+                            ? `Click below to launch a guided walkthrough of ${service.name} with sample manufacturing data.`
+                            : `We are building the ${service.name} demo experience. Register your interest to be notified when it is ready.`}
+                        </p>
+                        <Link
+                          href="/contact"
+                          className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
+                          style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
+                        >
+                          {service.status === 'live' ? 'Launch Demo' : 'Request Preview'}
+                          <ArrowRight className="w-4 h-4" />
+                        </Link>
+                      </div>
+                    </div>
+                  );
+                })()}
+              </div>
+            );
+          })()}
         </div>
       </section>
 


### PR DESCRIPTION
## What
Removes the browser mockup frame (traffic lights + URL bar) from the SQDCP demo section on `/solutions/sqdcp`.

## Why
The SQDCP demo now uses a real screenshot from sqdcp.oplytics.digital which already includes the full app UI (sidebar, header, breadcrumbs). The browser mockup frame created a redundant 'browser-in-browser' effect.

## How
- Added a `staticScreenshotSlugs` list in SolutionPage.tsx (currently only `['sqdcp']`)
- When slug is in that list, the demo renders directly with rounded border + 'Try It Live' hover overlay, but **without** the browser chrome (traffic lights + URL bar)
- All other solution pages are unchanged — they still get the browser mockup frame

## Scope
Only affects `/solutions/sqdcp`. Easy to extend to other slugs later by adding to the array.