### PR TITLE
fix: use real SQDCP screenshot on homepage card (correct graphicMap key)

### DIFF
--- a/client/src/components/shared/AnimatedServiceCard.tsx
+++ b/client/src/components/shared/AnimatedServiceCard.tsx
@@ -225,8 +225,8 @@ function CertificationGraphic() {
 const graphicMap: Record<string, React.FC> = {
   'policy-deployment': PolicyDeploymentGraphic,
   'oee-manager': OEEGaugeGraphic,
-  'sqdcp': SQDCPBoardGraphic,
-  'connect': ConnectGraphic,
+  'sqdcp-hub': SQDCPBoardGraphic,
+  'smartconnect': ConnectGraphic,
   'action-manager': ActionKanbanGraphic,
   'safety-manager': SafetyGraphic,
   'quality-manager': QualityGraphic,


### PR DESCRIPTION
## What
Fixes the graphicMap key mismatch in AnimatedServiceCard.tsx so the SQDCP card on the homepage shows the real dashboard screenshot instead of the fallback icon.

## Root Cause
The homepage passes `slug={service.id}` to AnimatedServiceCard, where SQDCP's `id` is `'sqdcp-hub'`. But the graphicMap key was `'sqdcp'` — so the lookup failed and it fell back to the icon.

Same issue for SmartConnect: `id` is `'smartconnect'` but graphicMap had `'connect'`.

## Fix
- Changed graphicMap key `'sqdcp'` → `'sqdcp-hub'`
- Changed graphicMap key `'connect'` → `'smartconnect'`
- SQDCPBoardGraphic now renders the real screenshot image