### PR TITLE
fix: equalise card grids, left-align section titles, show full SQDCP screenshot

### DIFF
--- a/client/src/components/shared/AnimatedServiceCard.tsx
+++ b/client/src/components/shared/AnimatedServiceCard.tsx
@@ -97,7 +97,7 @@ function SQDCPBoardGraphic() {
       <img
         src="https://files.manuscdn.com/user_upload_by_module/session_file/310419663031899852/KrztKyLzJbeuhpNg.webp"
         alt="SQDCP Dashboard — real data"
-        className="w-full h-full object-cover object-top"
+        className="w-full h-full object-contain object-center"
         loading="lazy"
       />
     </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -127,7 +127,7 @@ export default function Home() {
             </span>
             <div className="flex-1 h-px bg-gradient-to-r from-[#8C34E9]/20 to-transparent" />
           </div>
-          <StaggerContainer className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 sm:gap-6" variant="slide-up" staggerDelay={0.08}>
+          <StaggerContainer className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6" variant="slide-up" staggerDelay={0.08}>
             {coreServices.map(service => (
               <AnimatedServiceCard
                 key={service.id}
@@ -144,11 +144,10 @@ export default function Home() {
 
           {/* Delineation Line */}
           <div className="flex items-center gap-4 my-8 sm:my-10">
-            <div className="flex-1 h-px bg-gradient-to-r from-transparent via-[#1E2738] to-transparent" />
             <span className="text-[9px] sm:text-[10px] font-bold tracking-[0.2em] uppercase text-[#596475] whitespace-nowrap">
               Specialist Hubs
             </span>
-            <div className="flex-1 h-px bg-gradient-to-r from-transparent via-[#1E2738] to-transparent" />
+            <div className="flex-1 h-px bg-gradient-to-r from-[#1E2738]/40 to-transparent" />
           </div>
 
           {/* Hub Services */}


### PR DESCRIPTION
## What
Three layout fixes for the homepage solutions section.

## Changes
1. **Core Platform grid**: Changed from `xl:grid-cols-5` to `md:grid-cols-3` — now matches the Specialist Hubs grid so all cards are the same size
2. **Section titles left-aligned**: Both 'Core Platform' and 'Specialist Hubs' labels now left-align with a trailing gradient line (matching the existing Core Platform style)
3. **SQDCP screenshot fully visible**: Changed from `object-cover object-top` to `object-contain object-center` so the entire dashboard screenshot is visible within the card graphic area