### PR TITLE
fix: repair Explore Solutions link and remove See How It Works buttons from solution pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,6 +32,7 @@ function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
+      <Route path="/solutions" component={Home} />
       <Route path="/solutions/connect/checklist" component={ConnectChecklist} />
       <Route path="/solutions/connect/:role" component={ConnectRoleProposal} />
       <Route path="/solutions/:slug" component={SolutionPage} />

--- a/client/src/components/shared/HeroSection.tsx
+++ b/client/src/components/shared/HeroSection.tsx
@@ -2,7 +2,7 @@
  * TASK-04: Hero Section Component (Live / In-Development variants)
  * Design: "Neon Operations" — atmospheric hero with status-driven CTAs
  *
- * Live variant CTAs: 'See How It Works', 'View Plans' (links to /pricing)
+ * Live variant CTAs: 'View Plans' (links to /pricing)
  * In Development variant CTAs: 'Request Early Access', 'Join Waitlist'
  * Status badge: none for Live, purple 'In Development' badge for in-dev
  * Status driven by service config — no manual per-page edits.
@@ -26,8 +26,7 @@ export default function HeroSection({ headline, subheadline, subtext, status, ba
 
   const defaultCtas = isLive
     ? [
-        { label: 'See How It Works', href: '/contact', variant: 'primary' as const },
-        { label: 'View Plans', href: '/pricing', variant: 'secondary' as const },
+        { label: 'View Plans', href: '/pricing', variant: 'primary' as const },
       ]
     : [
         { label: 'Request Early Access', href: '/contact', variant: 'primary' as const },

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -79,7 +79,7 @@ export default function Home() {
         backgroundImage="https://d2xsxph8kpxj0f.cloudfront.net/310419663031899852/TqfjMS5mXpLDBG5ze8gzfz/hero-main-8i2QPeXPF5Zif5HP36QHAA.webp"
         customCtas={[
           { label: 'See How It Works', href: '/contact', variant: 'primary' },
-          { label: 'Explore Solutions', href: '#solutions', variant: 'secondary' },
+          { label: 'Explore Solutions', href: '/solutions', variant: 'secondary' },
         ]}
       />
 


### PR DESCRIPTION
## Summary

- **Explore Solutions dead anchor** — The button was pointing to `#solutions` which doesn't reliably work in this wouter SPA (the `ScrollToTop` component resets scroll position on every route change, killing hash navigation). Changed href to `/solutions` and added a `/solutions` route alias in `App.tsx` that renders the `Home` component (which contains the solutions grid section).

- **See How It Works buttons on solution pages** — All 8 solution pages inherit their hero CTAs from `HeroSection`'s `defaultCtas`. Removed the `See How It Works → /contact` entry from the live-service defaults. The Home page hero is unaffected as it supplies its own `customCtas` override.

## Files changed

| File | Change |
|------|--------|
| `client/src/App.tsx` | Add `<Route path="/solutions" component={Home} />` |
| `client/src/pages/Home.tsx` | `href: '#solutions'` → `href: '/solutions'` |
| `client/src/components/shared/HeroSection.tsx` | Remove `See How It Works` from `defaultCtas` for live services; promote `View Plans` to primary variant |

## Test plan

- [ ] Click "Explore Solutions" on the home page — should navigate to `/solutions` and show the platform services grid
- [ ] Visit each solution page (`/solutions/oee-manager`, `/solutions/sqdcp`, etc.) — hero should show only "View Plans" button, no "See How It Works"
- [ ] Home page hero still shows both "See How It Works" and "Explore Solutions" buttons unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)