### PR TITLE
fix: restore missing features sections on SQDCP and Connect pages; add taglines to all solution heroes

### DIFF
--- a/client/src/pages/SolutionPage.tsx
+++ b/client/src/pages/SolutionPage.tsx
@@ -49,7 +49,7 @@ const serviceFeatures: Record<string, { icon: React.ReactNode; title: string; de
     { icon: <Users className="w-5 h-5" />, title: 'Shift Handover', description: 'Digital shift handover reports with OEE summaries, open actions, and key events from the previous shift.' },
     { icon: <Target className="w-5 h-5" />, title: 'Target Management', description: 'Set OEE targets by line, product, and shift. Visual indicators show performance against target in real time.' },
   ],
-  'sqdcp-hub': [
+  'sqdcp': [
     { icon: <LayoutGrid className="w-5 h-5" />, title: 'Digital Tier Boards', description: 'Replace whiteboards with real-time digital SQDCP boards. Accessible from any device, anywhere.' },
     { icon: <Shield className="w-5 h-5" />, title: 'Safety First', description: 'Safety metrics front and centre. Track incidents, near-misses, and safety observations daily.' },
     { icon: <CheckCircle className="w-5 h-5" />, title: 'Quality Tracking', description: 'First-pass yield, scrap rates, and customer complaints. Quality data integrated from your QMS.' },
@@ -75,7 +75,7 @@ const serviceFeatures: Record<string, { icon: React.ReactNode; title: string; de
     { icon: <TrendingUp className="w-5 h-5" />, title: 'Catchball Process', description: 'Facilitate the catchball process digitally. Align top-down objectives with bottom-up feedback.' },
     { icon: <BarChart3 className="w-5 h-5" />, title: 'Progress Reviews', description: 'Monthly and quarterly review cadence with automated status updates and bowling charts.' },
   ],
-  'smartconnect': [
+  'connect': [
     { icon: <Plug className="w-5 h-5" />, title: 'Machine Connectivity', description: 'Connect to PLCs, SCADA systems, and industrial sensors. Support for OPC-UA, MQTT, Modbus, and more.' },
     { icon: <Zap className="w-5 h-5" />, title: 'Zero-Code Configuration', description: 'Visual configuration interface. Map machine signals to Oplytics data points without writing code.' },
     { icon: <BarChart3 className="w-5 h-5" />, title: 'Data Transformation', description: 'Transform raw machine data into meaningful metrics. Built-in calculation engine for OEE, cycle times, and more.' },
@@ -129,6 +129,7 @@ export default function SolutionPage() {
       {/* ── 1. HERO ── */}
       <HeroSection
         headline={service.name}
+        subheadline={service.tagline}
         subtext={service.description}
         status={service.status}
         backgroundImage={service.heroImage}


### PR DESCRIPTION
## Root cause

The `serviceFeatures` lookup map in `SolutionPage.tsx` was keyed by legacy IDs instead of the service slugs used by the current shared-ui catalog. Since features are looked up as `serviceFeatures[service.slug]`, both affected pages silently returned an empty array and rendered no features section at all.

## Changes

### `client/src/pages/SolutionPage.tsx`

| Before | After | Effect |
|--------|-------|--------|
| `'sqdcp-hub': [...]` | `'sqdcp': [...]` | SQDCP "Key Features" section restored (6 features) |
| `'smartconnect': [...]` | `'connect': [...]` | OplyticsConnect "Key Features" section restored (4 features) |
| `<HeroSection headline={...} subtext={...} ...>` | `<HeroSection headline={...} subheadline={service.tagline} subtext={...} ...>` | All 8 solution page heroes now display the service tagline in purple beneath the h1. Particularly important for SQDCP where "SQDCP Dashboard" alone is opaque without "Daily management boards, digitised". |

## Test plan

- [ ] `/solutions/sqdcp` — hero shows tagline "Daily management boards, digitised"; "Key Features" grid renders 6 items
- [ ] `/solutions/connect` — hero shows tagline "Integrate machines, sensors, and systems"; "Key Features" grid renders 4 items
- [ ] All other solution pages — hero tagline appears; features section unchanged

---

> **Image audit findings** (separate work item, no code changes in this PR):
>
> Two demo components use temporary `manuscdn.com` session-file URLs that expire and are likely already broken:
> - `SQDCPHubDemo.tsx:8` — the CloudFront replacement is already in `services.ts` as `demoImage` (`sqdcp-dashboard-real_bcc775e0.png`)
> - `PolicyDeploymentDemo.tsx:8` — added in PR #68; also needs migrating to CloudFront
>
> Services with "Coming Soon" placeholder demos (Safety Manager, Quality Manager, Certification Manager) — no AI-rendered images currently displayed; all three use inline React placeholder components.
>
> `demoImage` fields in `services.ts` for OEE Manager, Action Manager, Connect, Quality Manager, Safety Manager, Certification Manager are not currently rendered anywhere (overridden by their `DemoComponent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)