### PR TITLE
fix: migrate demo images from expiring manuscdn.com URLs to permanent CDN

### DIFF
--- a/client/src/components/demos/PolicyDeploymentDemo.tsx
+++ b/client/src/components/demos/PolicyDeploymentDemo.tsx
@@ -1,15 +1,31 @@
 /**
- * Policy Deployment Demo — Real screenshot from portal.oplytics.digital
+ * Policy Deployment Demo — Screenshot pending CDN upload
+ *
+ * A real screenshot (X-Matrix, The Vita Group) was captured in PR #68 but only
+ * committed as a manuscdn.com session-file URL which has since expired. The
+ * screenshot needs to be re-uploaded to the CloudFront CDN and the src below
+ * updated. Tracking: replace this placeholder once the permanent URL is known.
  */
+import { Target } from 'lucide-react';
+
 export default function PolicyDeploymentDemo() {
   return (
-    <div className="w-full">
-      <img
-        src="https://files.manuscdn.com/user_upload_by_module/session_file/310419663031899852/AcHzuaWALxjHEest.png"
-        alt="Policy Deployment X-Matrix — The Vita Group — real data"
-        className="w-full h-auto block"
-        loading="lazy"
-      />
+    <div className="aspect-video flex flex-col items-center justify-center p-8 text-center relative">
+      <div className="absolute inset-0 opacity-5" style={{
+        backgroundImage: 'linear-gradient(#F59E0B 1px, transparent 1px), linear-gradient(90deg, #F59E0B 1px, transparent 1px)',
+        backgroundSize: '40px 40px',
+      }} />
+      <div className="relative z-10">
+        <div className="w-16 h-16 rounded-full bg-[#F59E0B]/10 flex items-center justify-center mx-auto mb-6 border border-[#F59E0B]/20">
+          <Target className="w-7 h-7 text-[#F59E0B]" />
+        </div>
+        <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
+          Screenshot Coming Soon
+        </h3>
+        <p className="text-sm text-[#8890A0] max-w-md mx-auto">
+          A live walkthrough of the Policy Deployment X-Matrix and bowling charts will be available here shortly.
+        </p>
+      </div>
     </div>
   );
 }

--- a/client/src/components/demos/SQDCPHubDemo.tsx
+++ b/client/src/components/demos/SQDCPHubDemo.tsx
@@ -1,11 +1,12 @@
 /**
  * SQDCP Dashboard Demo — Real screenshot from sqdcp.oplytics.digital
+ * CDN URL migrated from manuscdn.com session file (PR #58) to permanent CloudFront.
  */
 export default function SQDCPHubDemo() {
   return (
     <div className="w-full">
       <img
-        src="https://files.manuscdn.com/user_upload_by_module/session_file/310419663031899852/KrztKyLzJbeuhpNg.webp"
+        src="https://d2xsxph8kpxj0f.cloudfront.net/310419663031899852/TqfjMS5mXpLDBG5ze8gzfz/sqdcp-dashboard-real_bcc775e0.png"
         alt="SQDCP Dashboard — Vita Group, Vita Mattress Middleton — real data"
         className="w-full h-auto block"
         loading="lazy"


### PR DESCRIPTION
## Summary

Removes two `manuscdn.com` session-file URLs from demo components. These are temporary upload URLs that expire and serve broken images.

---

### SQDCP — resolved ✅

`SQDCPHubDemo.tsx` was pointing to a `manuscdn.com` session URL. The permanent CloudFront URL for the same real screenshot (`sqdcp-dashboard-real_bcc775e0.png`) was already set in `services.ts` `demoImage` since PR #58 but was never copied into the demo component. Fixed by using that URL.

### Policy Deployment — placeholder ⚠️

`PolicyDeploymentDemo.tsx` was pointing to a `manuscdn.com` session URL added in PR #68. Unlike SQDCP, **no permanent CloudFront URL exists for this screenshot** — the `services.ts` `demoImage` (`demo-policy-YkQnvYo8xjtKQmKoSKVDXW.webp`) is the pre-#68 AI-rendered placeholder, not the real X-Matrix screenshot.

Converted to a "Screenshot Coming Soon" placeholder (same style as Safety/Quality/Certification Manager demos) to prevent a broken image. 

**Action required after merge:** Re-upload the Policy Deployment X-Matrix screenshot (The Vita Group) to CloudFront and update `PolicyDeploymentDemo.tsx` with the permanent URL.

---

## Test plan

- [ ] `/solutions/sqdcp` demo section — shows the real SQDCP dashboard screenshot
- [ ] `/solutions/policy-deployment` demo section — shows the amber "Screenshot Coming Soon" placeholder (no broken image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)