### PR TITLE
fix: restore Policy Deployment demo with permanent CloudFront screenshot

### DIFF
--- a/client/src/components/demos/PolicyDeploymentDemo.tsx
+++ b/client/src/components/demos/PolicyDeploymentDemo.tsx
@@ -1,31 +1,15 @@
 /**
- * Policy Deployment Demo — Screenshot pending CDN upload
- *
- * A real screenshot (X-Matrix, The Vita Group) was captured in PR #68 but only
- * committed as a manuscdn.com session-file URL which has since expired. The
- * screenshot needs to be re-uploaded to the CloudFront CDN and the src below
- * updated. Tracking: replace this placeholder once the permanent URL is known.
+ * Policy Deployment Demo — Real screenshot from portal.oplytics.digital
  */
-import { Target } from 'lucide-react';
-
 export default function PolicyDeploymentDemo() {
   return (
-    <div className="aspect-video flex flex-col items-center justify-center p-8 text-center relative">
-      <div className="absolute inset-0 opacity-5" style={{
-        backgroundImage: 'linear-gradient(#F59E0B 1px, transparent 1px), linear-gradient(90deg, #F59E0B 1px, transparent 1px)',
-        backgroundSize: '40px 40px',
-      }} />
-      <div className="relative z-10">
-        <div className="w-16 h-16 rounded-full bg-[#F59E0B]/10 flex items-center justify-center mx-auto mb-6 border border-[#F59E0B]/20">
-          <Target className="w-7 h-7 text-[#F59E0B]" />
-        </div>
-        <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
-          Screenshot Coming Soon
-        </h3>
-        <p className="text-sm text-[#8890A0] max-w-md mx-auto">
-          A live walkthrough of the Policy Deployment X-Matrix and bowling charts will be available here shortly.
-        </p>
-      </div>
+    <div className="w-full">
+      <img
+        src="https://d2xsxph8kpxj0f.cloudfront.net/310419663031899852/WWAck7XNk78XRtLpvPRn3L/Image31-03-2026at18.24_25a1d67b.png"
+        alt="Policy Deployment X-Matrix — The Vita Group — real data"
+        className="w-full h-auto block"
+        loading="lazy"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the "Screenshot Coming Soon" placeholder added in PR #72 with the real Policy Deployment X-Matrix screenshot, now that a permanent CloudFront URL is available.

Uses the same `static <img>` pattern as `SQDCPHubDemo.tsx`.

## Test plan

- [ ] `/solutions/policy-deployment` demo section shows the real X-Matrix screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)