### PR TITLE
fix: update SQDCP demo to latest screenshot

### DIFF
--- a/client/src/components/demos/SQDCPHubDemo.tsx
+++ b/client/src/components/demos/SQDCPHubDemo.tsx
@@ -6,7 +6,7 @@ export default function SQDCPHubDemo() {
   return (
     <div className="w-full">
       <img
-        src="https://d2xsxph8kpxj0f.cloudfront.net/310419663031899852/TqfjMS5mXpLDBG5ze8gzfz/sqdcp-dashboard-real_bcc775e0.png"
+        src="https://d2xsxph8kpxj0f.cloudfront.net/310419663031899852/WWAck7XNk78XRtLpvPRn3L/Image31-03-2026at18.29_abdd3957.png"
         alt="SQDCP Dashboard — Vita Group, Vita Mattress Middleton — real data"
         className="w-full h-auto block"
         loading="lazy"


### PR DESCRIPTION
Replaces the CloudFront image URL in `SQDCPHubDemo.tsx` with the updated screenshot.

## Test plan
- [ ] `/solutions/sqdcp` demo section shows the updated SQDCP dashboard screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)