### PR TITLE
feat(demos): remove browser chrome frame, add Try It Live overlay to all demos

### DIFF
--- a/client/src/components/demos/AnimatedDemoShell.tsx
+++ b/client/src/components/demos/AnimatedDemoShell.tsx
@@ -58,7 +58,7 @@ export default function AnimatedDemoShell({ serviceName, accentColor, phases, ch
   })();
 
   return (
-    <div className="relative w-full rounded-lg overflow-hidden" style={{ background: '#0a0e1a', border: '1px solid #1e2738' }}>
+    <div className="relative w-full" style={{ background: '#0a0e1a' }}>
       {/* Demo header bar */}
       <div className="flex items-center justify-between px-4 py-2.5" style={{ background: '#0d1220', borderBottom: '1px solid #1e2738' }}>
         <div className="flex items-center gap-2">

--- a/client/src/pages/SolutionPage.tsx
+++ b/client/src/pages/SolutionPage.tsx
@@ -180,14 +180,40 @@ export default function SolutionPage() {
             </p>
           </div>
 
-          {/* Slugs whose DemoComponent is a static screenshot (no browser mockup frame) */}
+          {/* All demos: no browser chrome, "Try It Live" hover overlay */}
           {(() => {
-            const staticScreenshotSlugs = ['sqdcp'];
-            const isStatic = staticScreenshotSlugs.includes(service.slug);
             const DemoComponent = demoComponents[service.slug];
 
-            /* ── Static screenshot path: image + "Try It Live" overlay, no browser chrome ── */
-            if (isStatic && DemoComponent) {
+            /* ── Shared "Try It Live" overlay ── */
+            const overlay = (
+              <div className="absolute inset-0 bg-[#080C16]/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col items-center justify-center">
+                <div className="w-16 h-16 rounded-full bg-[#8C34E9]/20 flex items-center justify-center mb-4 border border-[#8C34E9]/30">
+                  {service.status === 'live' ? (
+                    <Play className="w-7 h-7 text-[#C084FC] ml-1" />
+                  ) : (
+                    <Monitor className="w-7 h-7 text-[#C084FC]" />
+                  )}
+                </div>
+                <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
+                  {service.status === 'live' ? 'Try It Live' : 'Preview Coming Soon'}
+                </h3>
+                <p className="text-sm text-[#A0A8B8] max-w-md mx-auto mb-4 text-center px-4">
+                  {service.status === 'live'
+                    ? `Launch a guided walkthrough of ${service.name} with sample manufacturing data.`
+                    : `Register your interest to be notified when ${service.name} launches.`}
+                </p>
+                <Link
+                  href="/contact"
+                  className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
+                  style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
+                >
+                  {service.status === 'live' ? 'Request Live Demo' : 'Register Interest'}
+                  <ArrowRight className="w-4 h-4" />
+                </Link>
+              </div>
+            );
+
+            if (DemoComponent) {
               return (
                 <div className="relative rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden group">
                   <Suspense fallback={
@@ -197,8 +223,34 @@ export default function SolutionPage() {
                   }>
                     <DemoComponent />
                   </Suspense>
-                  <div className="absolute inset-0 bg-[#080C16]/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col items-center justify-center">
-                    <div className="w-16 h-16 rounded-full bg-[#8C34E9]/20 flex items-center justify-center mb-4 border border-[#8C34E9]/30">
+                  {overlay}
+                </div>
+              );
+            }
+
+            if (service.demoImage) {
+              return (
+                <div className="relative rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden group">
+                  <img
+                    src={service.demoImage}
+                    alt={`${service.name} dashboard screenshot`}
+                    className="w-full h-auto"
+                    loading="lazy"
+                  />
+                  {overlay}
+                </div>
+              );
+            }
+
+            return (
+              <div className="relative rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden group">
+                <div className="aspect-video flex flex-col items-center justify-center p-8 text-center relative">
+                  <div className="absolute inset-0 opacity-5" style={{
+                    backgroundImage: 'linear-gradient(#8C34E9 1px, transparent 1px), linear-gradient(90deg, #8C34E9 1px, transparent 1px)',
+                    backgroundSize: '40px 40px',
+                  }} />
+                  <div className="relative z-10">
+                    <div className="w-16 h-16 rounded-full bg-[#8C34E9]/10 flex items-center justify-center mx-auto mb-6 border border-[#8C34E9]/20">
                       {service.status === 'live' ? (
                         <Play className="w-7 h-7 text-[#C084FC] ml-1" />
                       ) : (
@@ -206,125 +258,24 @@ export default function SolutionPage() {
                       )}
                     </div>
                     <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
-                      {service.status === 'live' ? 'Try It Live' : 'Preview Coming Soon'}
+                      {service.status === 'live' ? 'Interactive Demo' : 'Preview Coming Soon'}
                     </h3>
-                    <p className="text-sm text-[#A0A8B8] max-w-md mx-auto mb-4 text-center px-4">
+                    <p className="text-sm text-[#8890A0] max-w-md mx-auto mb-6">
                       {service.status === 'live'
-                        ? `Launch a guided walkthrough of ${service.name} with sample manufacturing data.`
-                        : `Register your interest to be notified when ${service.name} launches.`}
+                        ? `Click below to launch a guided walkthrough of ${service.name} with sample manufacturing data.`
+                        : `We are building the ${service.name} demo experience. Register your interest to be notified when it is ready.`}
                     </p>
                     <Link
                       href="/contact"
                       className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
                       style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
                     >
-                      {service.status === 'live' ? 'Request Live Demo' : 'Register Interest'}
+                      {service.status === 'live' ? 'Launch Demo' : 'Request Preview'}
                       <ArrowRight className="w-4 h-4" />
                     </Link>
                   </div>
                 </div>
-              );
-            }
-
-            /* ── Default path: browser mockup frame wrapping animated demos / demoImage / placeholder ── */
-            return (
-              <div className="relative rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden">
-                <div className="flex items-center gap-2 px-4 py-3 border-b border-[#1E2738] bg-[#080C16]">
-                  <div className="flex gap-1.5">
-                    <div className="w-3 h-3 rounded-full bg-[#EF4444]/60" />
-                    <div className="w-3 h-3 rounded-full bg-[#F59E0B]/60" />
-                    <div className="w-3 h-3 rounded-full bg-[#22C55E]/60" />
-                  </div>
-                  <div className="flex-1 mx-4">
-                    <div className="bg-[#1E2738] rounded-md px-3 py-1.5 text-xs text-[#596475] font-mono">
-                      {service.subdomain || `${service.slug}.oplytics.digital`}
-                    </div>
-                  </div>
-                </div>
-
-                {(() => {
-                  if (DemoComponent) {
-                    return (
-                      <Suspense fallback={
-                        <div className="aspect-video flex items-center justify-center">
-                          <div className="animate-pulse text-[#596475] text-sm">Loading demo...</div>
-                        </div>
-                      }>
-                        <DemoComponent />
-                      </Suspense>
-                    );
-                  }
-                  if (service.demoImage) {
-                    return (
-                      <div className="relative group">
-                        <img
-                          src={service.demoImage}
-                          alt={`${service.name} dashboard screenshot`}
-                          className="w-full h-auto"
-                          loading="lazy"
-                        />
-                        <div className="absolute inset-0 bg-[#080C16]/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col items-center justify-center">
-                          <div className="w-16 h-16 rounded-full bg-[#8C34E9]/20 flex items-center justify-center mb-4 border border-[#8C34E9]/30">
-                            {service.status === 'live' ? (
-                              <Play className="w-7 h-7 text-[#C084FC] ml-1" />
-                            ) : (
-                              <Monitor className="w-7 h-7 text-[#C084FC]" />
-                            )}
-                          </div>
-                          <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
-                            {service.status === 'live' ? 'Try It Live' : 'Preview Coming Soon'}
-                          </h3>
-                          <p className="text-sm text-[#A0A8B8] max-w-md mx-auto mb-4 text-center px-4">
-                            {service.status === 'live'
-                              ? `Launch a guided walkthrough of ${service.name} with sample manufacturing data.`
-                              : `Register your interest to be notified when ${service.name} launches.`}
-                          </p>
-                          <Link
-                            href="/contact"
-                            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
-                            style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
-                          >
-                            {service.status === 'live' ? 'Request Live Demo' : 'Register Interest'}
-                            <ArrowRight className="w-4 h-4" />
-                          </Link>
-                        </div>
-                      </div>
-                    );
-                  }
-                  return (
-                    <div className="aspect-video flex flex-col items-center justify-center p-8 text-center relative">
-                      <div className="absolute inset-0 opacity-5" style={{
-                        backgroundImage: 'linear-gradient(#8C34E9 1px, transparent 1px), linear-gradient(90deg, #8C34E9 1px, transparent 1px)',
-                        backgroundSize: '40px 40px',
-                      }} />
-                      <div className="relative z-10">
-                        <div className="w-16 h-16 rounded-full bg-[#8C34E9]/10 flex items-center justify-center mx-auto mb-6 border border-[#8C34E9]/20">
-                          {service.status === 'live' ? (
-                            <Play className="w-7 h-7 text-[#C084FC] ml-1" />
-                          ) : (
-                            <Monitor className="w-7 h-7 text-[#C084FC]" />
-                          )}
-                        </div>
-                        <h3 className="text-lg font-bold text-white mb-2" style={{ fontFamily: 'Montserrat' }}>
-                          {service.status === 'live' ? 'Interactive Demo' : 'Preview Coming Soon'}
-                        </h3>
-                        <p className="text-sm text-[#8890A0] max-w-md mx-auto mb-6">
-                          {service.status === 'live'
-                            ? `Click below to launch a guided walkthrough of ${service.name} with sample manufacturing data.`
-                            : `We are building the ${service.name} demo experience. Register your interest to be notified when it is ready.`}
-                        </p>
-                        <Link
-                          href="/contact"
-                          className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
-                          style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
-                        >
-                          {service.status === 'live' ? 'Launch Demo' : 'Request Preview'}
-                          <ArrowRight className="w-4 h-4" />
-                        </Link>
-                      </div>
-                    </div>
-                  );
-                })()}
+                {overlay}
               </div>
             );
           })()}


### PR DESCRIPTION
## Summary

Two changes applied uniformly across all 8 demo components (SQDCPHubDemo, PolicyDeploymentDemo, OEEManagerDemo, ActionManagerDemo, ConnectDemo, SafetyManagerDemo, QualityManagerDemo, CertificationManagerDemo):

**1. Browser chrome removed**

`SolutionPage` previously had two rendering paths. Only `sqdcp` used the clean static-screenshot path; every other service got a macOS-style browser mockup frame (traffic lights + URL address bar). All `DemoComponent` slots now render without the chrome, matching what SQDCP already had.

**2. "Try It Live" hover overlay added to all**

The same overlay that SQDCP had (translucent dark wash on hover, purple play-button circle, "Try It Live" / "Preview Coming Soon" heading, CTA → `/contact`) now appears on every demo slot. The overlay JSX is defined once as a `const` and reused across the `DemoComponent`, `demoImage`, and generic-fallback branches.

**3. AnimatedDemoShell outer border removed** (`AnimatedDemoShell.tsx`)

OEE Manager, Action Manager, and Connect use `AnimatedDemoShell`, which previously added its own `border: 1px solid #1e2738` and `rounded-lg` — creating a visible double-frame inside `SolutionPage`'s own bordered container. The shell's outer div now carries only the background colour; rounding and border come from the `SolutionPage` wrapper.

## Files changed

| File | Change |
|------|--------|
| `client/src/pages/SolutionPage.tsx` | Collapsed two-path demo logic into one; overlay extracted as shared const; browser chrome removed; -49 net lines |
| `client/src/components/demos/AnimatedDemoShell.tsx` | Removed `rounded-lg`, `overflow-hidden`, and `border` from outer div |

## Test plan

- [ ] `/solutions/sqdcp` — screenshot + overlay unchanged ✓
- [ ] `/solutions/oee-manager` — no double border; animated demo visible; overlay appears on hover
- [ ] `/solutions/action-manager` — same as OEE
- [ ] `/solutions/connect` — same as OEE
- [ ] `/solutions/policy-deployment` — no browser chrome; placeholder + overlay appears on hover
- [ ] `/solutions/safety-manager` — same as policy-deployment
- [ ] `/solutions/quality-manager` — same as policy-deployment
- [ ] `/solutions/certification-manager` — same as policy-deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)