### PR TITLE
feat: Layer 1 & 2 Umami event tracking on marketing site

### DIFF
--- a/client/src/components/shared/ContactForm.tsx
+++ b/client/src/components/shared/ContactForm.tsx
@@ -40,7 +40,11 @@ export default function ContactForm({ context, compact = false }: ContactFormPro
     e.preventDefault();
     if (!validate()) return;
 
-    setSubmitting(true);
+      setSubmitting(true);
+    // Track form submission event
+    if (typeof window !== 'undefined' && (window as any).umami) {
+      (window as any).umami.track('contact_form_submit', { context: context || 'marketing-site' });
+    }
     try {
       const res = await fetch('https://portal.oplytics.digital/api/leads', {
         method: 'POST',
@@ -87,7 +91,7 @@ export default function ContactForm({ context, compact = false }: ContactFormPro
     }`;
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-5">
+    <form onSubmit={handleSubmit} className="space-y-5" data-umami-event="contact_form_start" data-umami-event-context={context || 'marketing-site'}>
       {context && <input type="hidden" name="context" value={context} />}
 
       <div className={compact ? 'space-y-4' : 'grid grid-cols-1 sm:grid-cols-2 gap-5'}>

--- a/client/src/components/shared/HeroSection.tsx
+++ b/client/src/components/shared/HeroSection.tsx
@@ -92,6 +92,9 @@ export default function HeroSection({ headline, subheadline, subtext, status, ba
             <Link
               key={i}
               href={cta.href}
+              data-umami-event="cta_click"
+              data-umami-event-button={cta.label.toLowerCase().replace(/\s+/g, '_')}
+              data-umami-event-location="hero"
               className={`inline-flex items-center gap-2 px-7 py-3 rounded-md text-sm font-bold tracking-wider transition-all duration-200 ${
                 cta.variant === 'primary'
                   ? 'text-white hover:opacity-90 glow-purple'

--- a/client/src/components/shared/MarketingHeader.tsx
+++ b/client/src/components/shared/MarketingHeader.tsx
@@ -90,6 +90,9 @@ export default function MarketingHeader() {
                           <Link
                             key={service.id}
                             href={`/solutions/${service.slug}`}
+                            data-umami-event="nav_click"
+                            data-umami-event-service={service.slug}
+                            data-umami-event-location="header_dropdown"
                             className="flex items-center gap-3 px-3 py-2.5 rounded-md hover:bg-[#1E2738]/60 transition-colors group"
                           >
                             <div className="w-2 h-2 rounded-full" style={{ background: getServiceStatusColor(service.status) }} />
@@ -114,6 +117,9 @@ export default function MarketingHeader() {
                           <Link
                             key={service.id}
                             href={`/solutions/${service.slug}`}
+                            data-umami-event="nav_click"
+                            data-umami-event-service={service.slug}
+                            data-umami-event-location="header_dropdown"
                             className="flex items-center gap-2 px-3 py-2 rounded-md hover:bg-[#1E2738]/60 transition-colors group"
                           >
                             <div className="w-1.5 h-1.5 rounded-full" style={{ background: getServiceStatusColor(service.status) }} />
@@ -137,6 +143,9 @@ export default function MarketingHeader() {
 
             <Link
               href="/login"
+              data-umami-event="cta_click"
+              data-umami-event-button="sign_in"
+              data-umami-event-location="header"
               className="px-5 py-2 rounded-md text-xs font-bold text-white tracking-wider transition-all duration-200 hover:opacity-90"
               style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
             >
@@ -220,6 +229,9 @@ export default function MarketingHeader() {
 
             <Link
               href="/login"
+              data-umami-event="cta_click"
+              data-umami-event-button="sign_in"
+              data-umami-event-location="header_mobile"
               className="block w-full text-center px-5 py-3 rounded-md text-sm font-bold text-white"
               style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
             >

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -236,6 +236,9 @@ export default function Home() {
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <Link
               href="/contact"
+              data-umami-event="cta_click"
+              data-umami-event-button="see_how_it_works"
+              data-umami-event-location="home_bottom"
               className="inline-flex items-center gap-2 px-7 py-3 rounded-md text-sm font-bold text-white tracking-wider hover:opacity-90 glow-purple w-full sm:w-auto justify-center"
               style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
             >
@@ -244,6 +247,9 @@ export default function Home() {
             </Link>
             <Link
               href="/pricing"
+              data-umami-event="cta_click"
+              data-umami-event-button="view_plans"
+              data-umami-event-location="home_bottom"
               className="inline-flex items-center gap-2 px-7 py-3 rounded-md text-sm font-bold text-[#8890A0] border border-[#1E2738] hover:border-[#8C34E9]/40 hover:text-white bg-[#0D1220]/60 w-full sm:w-auto justify-center"
             >
               View Plans

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -194,6 +194,10 @@ export default function Pricing() {
   function handleSizeChange(size: CompanySize) {
     setRoiSize(size);
     setRoiInputs({ size, ...sizePresets[size] });
+    // Track ROI calculator interaction
+    if (typeof window !== 'undefined' && (window as any).umami) {
+      (window as any).umami.track('roi_calculator_use', { company_size: size });
+    }
   }
 
   return (
@@ -258,6 +262,10 @@ export default function Pricing() {
                     </div>
                     <Link
                       href={plan.ctaHref}
+                      data-umami-event="cta_click"
+                      data-umami-event-button={plan.ctaLabel.toLowerCase().replace(/\s+/g, '_')}
+                      data-umami-event-location="pricing_featured"
+                      data-umami-event-plan={plan.name.toLowerCase().replace(/\s+/g, '_')}
                       className="inline-flex items-center justify-center gap-2 px-8 py-3 rounded-md text-sm font-bold tracking-wider text-white transition-all duration-200 hover:opacity-90"
                       style={{ background: 'linear-gradient(135deg, #22C55E 0%, #16A34A 100%)' }}
                     >
@@ -322,6 +330,10 @@ export default function Pricing() {
               </ul>
               <Link
                 href={plan.ctaHref}
+                data-umami-event="cta_click"
+                data-umami-event-button={plan.ctaLabel.toLowerCase().replace(/\s+/g, '_')}
+                data-umami-event-location="pricing_grid"
+                data-umami-event-plan={plan.name.toLowerCase().replace(/\s+/g, '_')}
                 className={`inline-flex items-center justify-center gap-2 w-full px-6 py-3 rounded-md text-sm font-bold tracking-wider transition-all duration-200 ${
                   plan.highlighted
                     ? 'text-white hover:opacity-90'
@@ -488,6 +500,9 @@ export default function Pricing() {
                 </p>
                 <Link
                   href="/contact"
+                  data-umami-event="cta_click"
+                  data-umami-event-button="get_personalised_roi_analysis"
+                  data-umami-event-location="pricing_roi_calculator"
                   className="inline-flex items-center gap-2 px-5 py-2 rounded-md text-sm font-bold text-white transition-all hover:opacity-90"
                   style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
                 >

--- a/client/src/pages/Resources.tsx
+++ b/client/src/pages/Resources.tsx
@@ -163,6 +163,9 @@ export default function Resources() {
                     </p>
                     <Link
                       href={`/resources/${article.slug}`}
+                      data-umami-event="content_click"
+                      data-umami-event-article={article.slug}
+                      data-umami-event-location="resources_grid"
                       className="inline-flex items-center gap-1.5 text-xs font-bold text-[#8C34E9] hover:text-[#C084FC] transition-colors"
                     >
                       Read Article

--- a/client/src/pages/SolutionPage.tsx
+++ b/client/src/pages/SolutionPage.tsx
@@ -204,6 +204,10 @@ export default function SolutionPage() {
                 </p>
                 <Link
                   href="/contact"
+                  data-umami-event="cta_click"
+                  data-umami-event-button={service.status === 'live' ? 'request_live_demo' : 'register_interest'}
+                  data-umami-event-location="solution_demo"
+                  data-umami-event-service={service.slug}
                   className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-white font-semibold text-sm transition-all hover:scale-105"
                   style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
                 >


### PR DESCRIPTION
## Summary
Instruments custom Umami events across the oplytics.digital marketing site for Layer 1 (Awareness) and Layer 2 (Interest) analytics.

## Events Added

| Event Name | Trigger | Metadata |
|---|---|---|
| `cta_click` | Any CTA button click | button, location, plan/service |
| `nav_click` | Solutions dropdown link | service, location |
| `contact_form_submit` | Contact form submission | context |
| `roi_calculator_use` | ROI calculator size selection | company_size |
| `content_click` | Resource article link | article, location |

## Files Changed
- `HeroSection.tsx` — hero CTA tracking
- `MarketingHeader.tsx` — sign in + solutions nav tracking
- `ContactForm.tsx` — form submission tracking
- `Home.tsx` — bottom CTA tracking
- `Pricing.tsx` — plan CTAs + ROI calculator tracking
- `SolutionPage.tsx` — demo CTA tracking
- `Resources.tsx` — article click tracking

## Scope
- Layer 1 + 2 on oplytics.digital only
- No subdomain tracking
- No business logic changes
- TypeScript: 0 errors