### PR TITLE
feat(ai): Opi orb assistant + usage metering

### DIFF
--- a/client/src/components/shared/MarketingAssistant.tsx
+++ b/client/src/components/shared/MarketingAssistant.tsx
@@ -1,0 +1,346 @@
+/**
+ * MarketingAssistant — the public-facing AI bot for the marketing site.
+ *
+ * Replaces the old AISupportEngineer (a flat purple circle + Lucide glyph) with
+ * a branded, animated gradient "orb" identity and a warmer first-run experience.
+ *
+ * Phase 0+1 of the marketing-AI roadmap:
+ *  - Animated conic-gradient orb launcher + in-chat avatars (Siri/Copilot style)
+ *  - Suggested prompts so the conversation never starts cold
+ *  - Proactive greeting nudge after a short dwell
+ *  - Perceived streaming via a typewriter reveal over the existing (non-streaming)
+ *    POST /api/ai/chat endpoint. True server token-streaming (SSE) is a Phase 2
+ *    backend item.
+ *
+ * Talks to the same REST endpoint as before, so no server changes are required.
+ */
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { X, Send, Loader2, User, Sparkles } from 'lucide-react';
+import { Streamdown } from 'streamdown';
+
+type Message = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+const SUGGESTED_PROMPTS = [
+  'What does Oplytics do?',
+  'How does OEE Manager work?',
+  'Can it integrate with our ERP?',
+  'Book a demo',
+];
+
+const GREETING =
+  "Alright! 👋 I'm Opi, your Oplytics guide. Ask me anything — what we do, how it works, or book a demo.";
+
+/** Brand-coloured animated gradient orb. Used for the launcher and the avatars. */
+function Orb({
+  size = 56,
+  active = false,
+  className = '',
+}: {
+  size?: number;
+  active?: boolean;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`oa-orb ${active ? 'oa-orb--active' : ''} ${className}`}
+      style={{ width: size, height: size }}
+      aria-hidden
+    >
+      <span className="oa-orb__core" />
+      <span className="oa-orb__sheen" />
+    </span>
+  );
+}
+
+export default function MarketingAssistant() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [showNudge, setShowNudge] = useState(false);
+  const [hasOpened, setHasOpened] = useState(false);
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  // Text currently being "typed out" for the latest assistant reply.
+  const [streamingText, setStreamingText] = useState<string | null>(null);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const typewriterRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Proactive greeting nudge — fire once, a few seconds after landing.
+  useEffect(() => {
+    if (hasOpened) return;
+    const t = setTimeout(() => setShowNudge(true), 6000);
+    return () => clearTimeout(t);
+  }, [hasOpened]);
+
+  // Keep the latest message in view as content streams in.
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, streamingText, isLoading]);
+
+  // Clean up the typewriter interval on unmount.
+  useEffect(() => {
+    return () => {
+      if (typewriterRef.current) clearInterval(typewriterRef.current);
+    };
+  }, []);
+
+  const openPanel = () => {
+    setIsOpen(true);
+    setHasOpened(true);
+    setShowNudge(false);
+  };
+
+  /** Reveal an assistant reply character-by-character for a "live" feel. */
+  const typewriterReveal = useCallback((full: string) => {
+    if (typewriterRef.current) clearInterval(typewriterRef.current);
+    setStreamingText('');
+    let i = 0;
+    // Reveal a few chars per tick so long answers don't crawl.
+    const stepSize = Math.max(1, Math.round(full.length / 240));
+    typewriterRef.current = setInterval(() => {
+      i += stepSize;
+      if (i >= full.length) {
+        if (typewriterRef.current) clearInterval(typewriterRef.current);
+        setStreamingText(null);
+        setMessages((prev) => [...prev, { role: 'assistant', content: full }]);
+      } else {
+        setStreamingText(full.slice(0, i));
+      }
+    }, 16);
+  }, []);
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || isLoading || streamingText !== null) return;
+
+      const userMessage: Message = { role: 'user', content: trimmed };
+      const newMessages = [...messages, userMessage];
+      setMessages(newMessages);
+      setInput('');
+      setIsLoading(true);
+
+      try {
+        const response = await fetch('/api/ai/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messages: newMessages }),
+        });
+        if (!response.ok) throw new Error('Failed to chat');
+        const data = await response.json();
+        typewriterReveal(data.content);
+      } catch (error) {
+        console.error('Chat error:', error);
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: 'assistant',
+            content: "Sorry mate, I've hit a bit of a snag. Give it another go?",
+          },
+        ]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [messages, isLoading, streamingText, typewriterReveal]
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send(input);
+    }
+  };
+
+  const busy = isLoading || streamingText !== null;
+
+  return (
+    <>
+      <style>{ORB_STYLES}</style>
+
+      <div className="fixed bottom-6 right-6 z-[9999] flex flex-col items-end gap-3">
+        {/* ─── Open chat panel ─── */}
+        {isOpen && (
+          <div
+            className="oa-panel flex w-[92vw] max-w-[400px] flex-col overflow-hidden rounded-2xl"
+            style={{ height: 'min(560px, 75vh)' }}
+          >
+            {/* Header */}
+            <div
+              className="flex items-center justify-between gap-3 px-4 py-3.5"
+              style={{
+                background: 'linear-gradient(135deg, rgba(140,52,233,0.22), rgba(29,184,206,0.14))',
+                borderBottom: '1px solid #1E2738',
+              }}
+            >
+              <div className="flex items-center gap-3">
+                <Orb size={36} active={busy} />
+                <div>
+                  <h3 className="text-sm font-bold leading-none text-white" style={{ fontFamily: 'Montserrat' }}>
+                    Opi
+                  </h3>
+                  <p className="mt-1 text-[11px] text-white/55">Oplytics AI guide</p>
+                </div>
+              </div>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+                aria-label="Close assistant"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            {/* Messages */}
+            <div ref={scrollRef} className="custom-scrollbar flex-1 space-y-4 overflow-y-auto p-4">
+              {messages.length === 0 && (
+                <div className="space-y-4 py-4 text-center">
+                  <Orb size={64} className="mx-auto" />
+                  <p className="px-4 text-sm leading-relaxed text-white/80">{GREETING}</p>
+                  <div className="flex flex-wrap justify-center gap-2 pt-2">
+                    {SUGGESTED_PROMPTS.map((p) => (
+                      <button
+                        key={p}
+                        onClick={() => send(p)}
+                        className="rounded-full border border-[#1E2738] bg-[#0D1220] px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:border-[#8C34E9] hover:text-white"
+                      >
+                        {p}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {messages.map((msg, i) => (
+                <MessageRow key={i} role={msg.role}>
+                  {msg.content}
+                </MessageRow>
+              ))}
+
+              {/* Live typewriter reveal of the latest assistant reply */}
+              {streamingText !== null && <MessageRow role="assistant">{streamingText}</MessageRow>}
+
+              {/* Thinking indicator (before the first token arrives) */}
+              {isLoading && streamingText === null && (
+                <div className="flex items-start gap-3">
+                  <Orb size={32} active className="shrink-0" />
+                  <div className="rounded-2xl rounded-tl-sm border border-[#1E2738] bg-[#0D1220] px-3 py-2.5">
+                    <Loader2 className="h-4 w-4 animate-spin text-white/50" />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Input */}
+            <div className="border-t border-[#1E2738] bg-[#080C16] p-3">
+              <div className="flex items-end gap-2">
+                <textarea
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Ask Opi anything…"
+                  className="max-h-[120px] min-h-[40px] flex-1 resize-none rounded-lg border border-[#1E2738] bg-[#0D1220] px-3 py-2 text-sm text-white placeholder-[#596475] focus:border-[#8C34E9] focus:outline-none"
+                  rows={1}
+                />
+                <button
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+                  style={{ background: 'linear-gradient(135deg, #8C34E9, #1DB8CE)' }}
+                  onClick={() => send(input)}
+                  disabled={!input.trim() || busy}
+                >
+                  <Send className="h-4 w-4" />
+                </button>
+              </div>
+              <p className="mt-2 text-center text-[10px] text-white/30">
+                Opi can make mistakes — verify anything important.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ─── Proactive greeting nudge ─── */}
+        {!isOpen && showNudge && (
+          <button
+            onClick={openPanel}
+            className="oa-nudge flex max-w-[240px] items-center gap-2 rounded-2xl rounded-br-sm border border-[#1E2738] bg-[#0D1220] px-3.5 py-2.5 text-left text-xs font-medium text-white shadow-xl"
+          >
+            <Sparkles className="h-3.5 w-3.5 shrink-0 text-[#1DB8CE]" />
+            Got a question? Ask Opi 👋
+          </button>
+        )}
+
+        {/* ─── Launcher orb ─── */}
+        {!isOpen && (
+          <button onClick={openPanel} aria-label="Open AI assistant" className="oa-launcher transition-transform duration-300 hover:scale-110">
+            <Orb size={60} />
+          </button>
+        )}
+      </div>
+    </>
+  );
+}
+
+/** A single chat row with the appropriate avatar + bubble styling. */
+function MessageRow({ role, children }: { role: Message['role']; children: string }) {
+  const isUser = role === 'user';
+  return (
+    <div className={`flex items-start gap-3 ${isUser ? 'justify-end' : 'justify-start'}`}>
+      {!isUser && <Orb size={32} className="shrink-0" />}
+      <div
+        className={`max-w-[80%] px-3 py-2.5 text-sm leading-relaxed ${
+          isUser ? 'rounded-2xl rounded-tr-sm text-white' : 'rounded-2xl rounded-tl-sm text-[#E2E8F0]'
+        }`}
+        style={
+          isUser
+            ? { background: 'linear-gradient(135deg, #8C34E9, #5B1FA6)' }
+            : { background: '#0D1220', border: '1px solid #1E2738' }
+        }
+      >
+        {isUser ? (
+          <p className="whitespace-pre-wrap">{children}</p>
+        ) : (
+          <div className="oa-prose prose prose-sm prose-invert max-w-none">
+            <Streamdown>{children}</Streamdown>
+          </div>
+        )}
+      </div>
+      {isUser && (
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#1E2738]">
+          <User className="h-4 w-4 text-[#596475]" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+const ORB_STYLES = `
+@keyframes oa-spin { to { transform: rotate(360deg); } }
+@keyframes oa-breathe { 0%,100% { transform: scale(1); } 50% { transform: scale(1.06); } }
+@keyframes oa-pop { 0% { opacity: 0; transform: translateY(8px) scale(.96); } 100% { opacity: 1; transform: translateY(0) scale(1); } }
+
+.oa-orb { position: relative; display: inline-block; border-radius: 9999px; flex: none;
+  animation: oa-breathe 4s ease-in-out infinite; }
+.oa-orb__core { position: absolute; inset: 0; border-radius: 9999px;
+  background: conic-gradient(from 0deg, #8C34E9, #1DB8CE, #8C34E9);
+  animation: oa-spin 6s linear infinite;
+  box-shadow: 0 0 18px rgba(140,52,233,0.45), 0 0 8px rgba(29,184,206,0.4); }
+.oa-orb__sheen { position: absolute; inset: 18%; border-radius: 9999px;
+  background: radial-gradient(circle at 32% 28%, rgba(255,255,255,0.9), rgba(255,255,255,0.15) 45%, transparent 60%);
+  mix-blend-mode: screen; }
+.oa-orb--active { animation-duration: 1.6s; }
+.oa-orb--active .oa-orb__core { animation-duration: 2s; }
+
+.oa-launcher { display: block; line-height: 0; border-radius: 9999px;
+  filter: drop-shadow(0 8px 24px rgba(140,52,233,0.45)); }
+.oa-nudge { animation: oa-pop .3s ease-out both; }
+.oa-panel { background: #080C16; border: 1px solid #1E2738;
+  box-shadow: 0 24px 64px rgba(0,0,0,0.6); animation: oa-pop .3s ease-out both; }
+.oa-prose p { margin: 0; }
+.oa-prose p + p { margin-top: .5rem; }
+.oa-prose a { color: #1DB8CE; }
+`;

--- a/client/src/components/shared/MarketingLayout.tsx
+++ b/client/src/components/shared/MarketingLayout.tsx
@@ -5,7 +5,7 @@
 import { type ReactNode } from 'react';
 import MarketingHeader from './MarketingHeader';
 import MarketingFooter from './MarketingFooter';
-import AISupportEngineer from './AISupportEngineer';
+import MarketingAssistant from './MarketingAssistant';
 import CookieConsent from './CookieConsent';
 
 interface MarketingLayoutProps {
@@ -27,7 +27,7 @@ export default function MarketingLayout({ children }: MarketingLayoutProps) {
       </main>
 
       <MarketingFooter />
-      <AISupportEngineer />
+      <MarketingAssistant />
       <CookieConsent />
     </div>
   );

--- a/server/aiUsageClient.ts
+++ b/server/aiUsageClient.ts
@@ -1,0 +1,107 @@
+/**
+ * Client for the central AI usage ledger (Business Hub).
+ *
+ * The marketing site reports every Opi call here and asks the budget guard
+ * before spending. Both are best-effort and FAIL-OPEN: if the ledger isn't
+ * configured or is unreachable, Opi keeps working (just un-metered) so the
+ * marketing site is never taken down by the ledger.
+ */
+import { ENV } from "./env";
+
+// gemini-2.5-flash pricing (USD per 1k tokens) — keep in sync with core-server.
+const COST_RATE = { inputPer1k: 0.000075, outputPer1k: 0.0003 };
+const estTokens = (s: string) => Math.ceil((s?.length ?? 0) / 4);
+
+const ledgerBase = () => ENV.AI_USAGE_LEDGER_URL?.replace(/\/$/, "");
+const configured = () => !!ledgerBase() && !!ENV.AI_USAGE_INGEST_SECRET;
+
+const headers = () => ({
+  "content-type": "application/json",
+  "x-ai-usage-secret": ENV.AI_USAGE_INGEST_SECRET as string,
+});
+
+export interface BudgetVerdict {
+  allowed: boolean;
+  reason?: string;
+}
+
+/** Ask the ledger whether this call may proceed. Defaults to allow. */
+export async function checkBudget(req: {
+  app: string;
+  mode?: string;
+  enterpriseId?: number;
+  estPromptTokens?: number;
+}): Promise<BudgetVerdict> {
+  if (!configured()) return { allowed: true };
+  try {
+    const r = await fetch(`${ledgerBase()}/api/ai-usage/check`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify(req),
+    });
+    if (!r.ok) return { allowed: true };
+    return (await r.json()) as BudgetVerdict;
+  } catch {
+    return { allowed: true };
+  }
+}
+
+export interface UsageEvent {
+  app: string;
+  label?: string;
+  mode?: string;
+  model?: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  estCostUsd: number;
+  estimated: boolean;
+  page?: string;
+}
+
+/** Record one usage event. Best-effort; never throws. */
+export async function reportUsage(event: UsageEvent): Promise<void> {
+  if (!configured()) return;
+  try {
+    await fetch(`${ledgerBase()}/api/ai-usage/ingest`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify(event),
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Build a usage event from an LLM response, using real token counts when present. */
+export function buildUsage(opts: {
+  model?: string;
+  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+  promptText: string;
+  completionText: string;
+  page?: string;
+}): UsageEvent {
+  const provided = opts.usage;
+  const estimated = !provided;
+  const promptTokens = provided?.prompt_tokens ?? estTokens(opts.promptText);
+  const completionTokens = provided?.completion_tokens ?? estTokens(opts.completionText);
+  const totalTokens = provided?.total_tokens ?? promptTokens + completionTokens;
+  const estCostUsd =
+    Math.round(
+      ((promptTokens / 1000) * COST_RATE.inputPer1k +
+        (completionTokens / 1000) * COST_RATE.outputPer1k) *
+        1e6
+    ) / 1e6;
+  return {
+    app: "marketing-site",
+    label: "opi",
+    mode: "marketing",
+    model: opts.model,
+    promptTokens,
+    completionTokens,
+    totalTokens,
+    estCostUsd,
+    estimated,
+    page: opts.page,
+  };
+}

--- a/server/env.ts
+++ b/server/env.ts
@@ -5,6 +5,10 @@ const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
   FORGE_API_URL: z.string().url().optional(),
   FORGE_API_KEY: z.string().min(1),
+  // AI usage ledger (Business Hub). Both optional — metering is skipped (fail-open)
+  // until they're set, so the site runs fine without them.
+  AI_USAGE_LEDGER_URL: z.string().url().optional(),
+  AI_USAGE_INGEST_SECRET: z.string().optional(),
 });
 
 export const ENV = envSchema.parse(process.env);

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { invokeLLM } from "./llm";
 import { ENV } from "./env";
+import { checkBudget, reportUsage, buildUsage } from "./aiUsageClient";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,17 +32,46 @@ async function startServer() {
   // AI Chat Endpoint
   app.post("/api/ai/chat", async (req, res) => {
     try {
-      const { messages } = req.body;
-      
+      const { messages, page } = req.body ?? {};
+      const history: any[] = messages ?? [];
+      const promptText = history
+        .map((m) => (typeof m.content === "string" ? m.content : ""))
+        .join(" ");
+
+      // Cost control: ask the ledger's budget guard before spending.
+      const verdict = await checkBudget({
+        app: "marketing-site",
+        mode: "marketing",
+        estPromptTokens: Math.ceil(promptText.length / 4),
+      });
+      if (!verdict.allowed) {
+        return res.json({
+          content: verdict.reason ?? "Opi's having a quick breather — try again shortly.",
+        });
+      }
+
       const response = await invokeLLM({
         messages: [
           { role: "system", content: SUPPORT_ENGINEER_PERSONA },
-          ...messages
+          ...history,
         ],
         model: "gemini-2.5-flash", // Using the default model from invokeLLM
       });
 
-      res.json({ content: response.choices[0].message.content });
+      const content = response.choices[0].message.content;
+
+      // Metering: record the call (best-effort, fails open).
+      await reportUsage(
+        buildUsage({
+          model: response.model,
+          usage: response.usage,
+          promptText,
+          completionText: typeof content === "string" ? content : "",
+          page,
+        })
+      );
+
+      res.json({ content });
     } catch (error) {
       console.error("AI Chat Error:", error);
       res.status(500).json({ error: "Failed to generate response" });


### PR DESCRIPTION
## Summary
Two things: a far better-looking marketing AI bot, and wiring it into the cost ledger.

### New look — "Opi" the orb
- New `MarketingAssistant.tsx` replaces `AISupportEngineer` in `MarketingLayout`: an animated conic-gradient orb (purple→cyan, spinning core, breathing, faster pulse while thinking), glassmorphism panel on the brand palette.
- Suggested prompts so it never starts cold, a proactive greeting nudge, and perceived streaming (typewriter reveal) over the existing non-streaming endpoint.

### Cost metering
- `server/aiUsageClient.ts` — `checkBudget` before each call + `reportUsage` after, posting to the Business Hub ledger with a shared-secret header. **Fail-open**: if `AI_USAGE_LEDGER_URL` / `AI_USAGE_INGEST_SECRET` aren't set or the ledger is down, Opi keeps working un-metered.
- Wired into `/api/ai/chat`: a blocked call returns a friendly message and spends nothing; a successful call is recorded with real token counts.

## Env (both optional)
`AI_USAGE_LEDGER_URL`, `AI_USAGE_INGEST_SECRET` (same secret as the ledger).

## Tests
`tsc --noEmit` clean; `vite build` + esbuild green.

## Notes
The old `AISupportEngineer.tsx` is left in place for easy comparison/rollback. A follow-up can adopt core-server's `createSupportEngine` (shared knowledge + metering in one) once `@pablo2410/core-server@0.3.0` is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)