### PR TITLE
feat(ai): Opi uses the shared knowledge engine

### DIFF
--- a/client/src/components/shared/MarketingAssistant.tsx
+++ b/client/src/components/shared/MarketingAssistant.tsx
@@ -129,7 +129,10 @@ export default function MarketingAssistant() {
         const response = await fetch('/api/ai/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ messages: newMessages }),
+          body: JSON.stringify({
+            messages: newMessages,
+            page: typeof window !== 'undefined' ? window.location.pathname : undefined,
+          }),
         });
         if (!response.ok) throw new Error('Failed to chat');
         const data = await response.json();

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@pablo2410/core-server": "^0.3.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
+      '@pablo2410/core-server':
+        specifier: ^0.3.0
+        version: 0.3.0(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
       '@pablo2410/shared-ui':
         specifier: 0.3.5
         version: 0.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
@@ -861,6 +864,24 @@ packages:
 
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
+
+  '@pablo2410/core-server@0.3.0':
+    resolution: {integrity: sha512-jhbh6jpgiVmtJnMhml6qjuY2toZICmux9hbmpRENtKnpdK2loItJ3QBQpmi1zNtw4KWbGzn7P1JvGVxR63grHQ==}
+    peerDependencies:
+      '@trpc/server': '>=11.0.0'
+      axios: '>=1.0.0'
+      cookie: '>=0.6.0'
+      express: '>=4.0.0'
+      jose: '>=5.0.0'
+    peerDependenciesMeta:
+      axios:
+        optional: true
+      cookie:
+        optional: true
+      express:
+        optional: true
+      jose:
+        optional: true
 
   '@pablo2410/shared-ui@0.3.5':
     resolution: {integrity: sha512-gcjeIsoQSdDdTLcJDNzZpU8dsslBf+zLg524PWYx2JvYSgULOMCwWHFFhmUAakNTTvdq628RaMoHWmISIREokg==}
@@ -1775,6 +1796,12 @@ packages:
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@trpc/server@11.17.0':
+    resolution: {integrity: sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.7.2'
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -4278,6 +4305,14 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
+  '@pablo2410/core-server@0.3.0(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
+    dependencies:
+      '@trpc/server': 11.17.0(typescript@5.6.3)
+    optionalDependencies:
+      axios: 1.13.6
+      cookie: 0.7.2
+      express: 4.22.1
+
   '@pablo2410/shared-ui@0.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5203,6 +5238,10 @@ snapshots:
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
+  '@trpc/server@11.17.0(typescript@5.6.3)':
+    dependencies:
+      typescript: 5.6.3
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/server/aiUsageClient.ts
+++ b/server/aiUsageClient.ts
@@ -1,107 +1,81 @@
 /**
- * Client for the central AI usage ledger (Business Hub).
+ * Ledger hooks for core-server's createLLMClient — reports AI usage and checks
+ * budgets against the central ledger (Business Hub).
  *
- * The marketing site reports every Opi call here and asks the budget guard
- * before spending. Both are best-effort and FAIL-OPEN: if the ledger isn't
- * configured or is unreachable, Opi keeps working (just un-metered) so the
- * marketing site is never taken down by the ledger.
+ * Fail-open and best-effort: if the ledger isn't configured (no URL/secret) or
+ * is unreachable, calls are allowed and usage is silently dropped, so the ledger
+ * never affects this app. Translates core-server's event shape to the ledger's
+ * REST contract (flattening user → userRole/enterpriseId).
  */
-import { ENV } from "./env";
+import type {
+  UsageEvent,
+  GuardRequest,
+  GuardResult,
+  LLMClientOptions,
+} from "@pablo2410/core-server";
 
-// gemini-2.5-flash pricing (USD per 1k tokens) — keep in sync with core-server.
-const COST_RATE = { inputPer1k: 0.000075, outputPer1k: 0.0003 };
-const estTokens = (s: string) => Math.ceil((s?.length ?? 0) / 4);
+type LedgerConfig = { ledgerUrl?: string; secret?: string };
 
-const ledgerBase = () => ENV.AI_USAGE_LEDGER_URL?.replace(/\/$/, "");
-const configured = () => !!ledgerBase() && !!ENV.AI_USAGE_INGEST_SECRET;
+const toEnterpriseId = (v: unknown): number | undefined => {
+  const n = typeof v === "number" ? v : typeof v === "string" ? parseInt(v, 10) : NaN;
+  return Number.isFinite(n) ? n : undefined;
+};
 
-const headers = () => ({
-  "content-type": "application/json",
-  "x-ai-usage-secret": ENV.AI_USAGE_INGEST_SECRET as string,
-});
+export function createLedgerHooks(
+  config: LedgerConfig
+): Pick<LLMClientOptions, "onUsage" | "guard"> {
+  const base = config.ledgerUrl?.replace(/\/$/, "");
+  const configured = !!base && !!config.secret;
+  const headers = () => ({
+    "content-type": "application/json",
+    "x-ai-usage-secret": config.secret as string,
+  });
 
-export interface BudgetVerdict {
-  allowed: boolean;
-  reason?: string;
-}
-
-/** Ask the ledger whether this call may proceed. Defaults to allow. */
-export async function checkBudget(req: {
-  app: string;
-  mode?: string;
-  enterpriseId?: number;
-  estPromptTokens?: number;
-}): Promise<BudgetVerdict> {
-  if (!configured()) return { allowed: true };
-  try {
-    const r = await fetch(`${ledgerBase()}/api/ai-usage/check`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify(req),
-    });
-    if (!r.ok) return { allowed: true };
-    return (await r.json()) as BudgetVerdict;
-  } catch {
-    return { allowed: true };
-  }
-}
-
-export interface UsageEvent {
-  app: string;
-  label?: string;
-  mode?: string;
-  model?: string;
-  promptTokens: number;
-  completionTokens: number;
-  totalTokens: number;
-  estCostUsd: number;
-  estimated: boolean;
-  page?: string;
-}
-
-/** Record one usage event. Best-effort; never throws. */
-export async function reportUsage(event: UsageEvent): Promise<void> {
-  if (!configured()) return;
-  try {
-    await fetch(`${ledgerBase()}/api/ai-usage/ingest`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify(event),
-    });
-  } catch {
-    /* best-effort */
-  }
-}
-
-/** Build a usage event from an LLM response, using real token counts when present. */
-export function buildUsage(opts: {
-  model?: string;
-  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
-  promptText: string;
-  completionText: string;
-  page?: string;
-}): UsageEvent {
-  const provided = opts.usage;
-  const estimated = !provided;
-  const promptTokens = provided?.prompt_tokens ?? estTokens(opts.promptText);
-  const completionTokens = provided?.completion_tokens ?? estTokens(opts.completionText);
-  const totalTokens = provided?.total_tokens ?? promptTokens + completionTokens;
-  const estCostUsd =
-    Math.round(
-      ((promptTokens / 1000) * COST_RATE.inputPer1k +
-        (completionTokens / 1000) * COST_RATE.outputPer1k) *
-        1e6
-    ) / 1e6;
-  return {
-    app: "marketing-site",
-    label: "opi",
-    mode: "marketing",
-    model: opts.model,
-    promptTokens,
-    completionTokens,
-    totalTokens,
-    estCostUsd,
-    estimated,
-    page: opts.page,
+  const guard = async (req: GuardRequest): Promise<GuardResult> => {
+    if (!configured) return { allowed: true };
+    try {
+      const r = await fetch(`${base}/api/ai-usage/check`, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({
+          app: req.app,
+          mode: req.mode,
+          enterpriseId: toEnterpriseId(req.user?.enterpriseId),
+          estPromptTokens: req.estPromptTokens,
+        }),
+      });
+      if (!r.ok) return { allowed: true };
+      return (await r.json()) as GuardResult;
+    } catch {
+      return { allowed: true };
+    }
   };
+
+  const onUsage = async (event: UsageEvent): Promise<void> => {
+    if (!configured) return;
+    try {
+      await fetch(`${base}/api/ai-usage/ingest`, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({
+          app: event.app,
+          label: event.label,
+          mode: event.mode,
+          model: event.model,
+          promptTokens: event.promptTokens,
+          completionTokens: event.completionTokens,
+          totalTokens: event.totalTokens,
+          estCostUsd: event.estCostUsd,
+          estimated: event.estimated,
+          userRole: event.user?.role,
+          enterpriseId: toEnterpriseId(event.user?.enterpriseId),
+          page: event.page,
+        }),
+      });
+    } catch {
+      /* best-effort */
+    }
+  };
+
+  return { onUsage, guard };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,26 +2,29 @@ import express from "express";
 import { createServer } from "http";
 import path from "path";
 import { fileURLToPath } from "url";
-import { invokeLLM } from "./llm";
+import { createSupportEngine, LLMBudgetError } from "@pablo2410/core-server";
 import { ENV } from "./env";
-import { checkBudget, reportUsage, buildUsage } from "./aiUsageClient";
+import { createLedgerHooks } from "./aiUsageClient";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const SUPPORT_ENGINEER_PERSONA = `
-You are the Oplytics AI Support Engineer, a knowledgeable and friendly assistant for the Oplytics platform.
-Your personality is relaxed, cheeky, and fun, but you are highly competent and professional when it comes to operational safety and platform technicals.
-Think of yourself as a "knowledgeable mate on the factory floor" rather than a corporate FAQ bot.
-
-Key Guidelines:
-- Use a conversational, slightly informal tone (e.g., "Alright mate," "No worries," "Spot on").
-- Be proactive in helping users with platform setup, training, and troubleshooting.
-- For safety or incident reporting, maintain a serious and helpful demeanor while keeping the relaxed tone.
-- If you don\'t know something, be honest but try to guide the user to the right place.
-- You are currently on the Public Marketing Site. Focus on features, benefits, and booking demos.
-- Never discuss competitor products. If asked about pricing, direct the user to the contact page at /contact.
-`;
+// Opi — the shared support engine in marketing mode. Persona + Oplytics
+// knowledge base live in @pablo2410/core-server; metering + budget guard are
+// injected so every call is recorded and cost-controlled via the ledger.
+const supportEngine = createSupportEngine(
+  { forgeApiUrl: ENV.FORGE_API_URL ?? "", forgeApiKey: ENV.FORGE_API_KEY },
+  {
+    knowledgeLimit: 6,
+    metering: {
+      app: "marketing-site",
+      ...createLedgerHooks({
+        ledgerUrl: ENV.AI_USAGE_LEDGER_URL,
+        secret: ENV.AI_USAGE_INGEST_SECRET,
+      }),
+    },
+  }
+);
 
 async function startServer() {
   const app = express();
@@ -29,50 +32,23 @@ async function startServer() {
   
   app.use(express.json());
 
-  // AI Chat Endpoint
+  // AI Chat Endpoint — Opi (marketing persona + shared knowledge base).
+  // Knowledge retrieval, persona, metering and the budget guard are all handled
+  // inside the engine; we just pass the conversation and the current page.
   app.post("/api/ai/chat", async (req, res) => {
     try {
       const { messages, page } = req.body ?? {};
-      const history: any[] = messages ?? [];
-      const promptText = history
-        .map((m) => (typeof m.content === "string" ? m.content : ""))
-        .join(" ");
-
-      // Cost control: ask the ledger's budget guard before spending.
-      const verdict = await checkBudget({
-        app: "marketing-site",
+      const { content } = await supportEngine.chat({
         mode: "marketing",
-        estPromptTokens: Math.ceil(promptText.length / 4),
+        messages: messages ?? [],
+        context: { page },
       });
-      if (!verdict.allowed) {
-        return res.json({
-          content: verdict.reason ?? "Opi's having a quick breather — try again shortly.",
-        });
-      }
-
-      const response = await invokeLLM({
-        messages: [
-          { role: "system", content: SUPPORT_ENGINEER_PERSONA },
-          ...history,
-        ],
-        model: "gemini-2.5-flash", // Using the default model from invokeLLM
-      });
-
-      const content = response.choices[0].message.content;
-
-      // Metering: record the call (best-effort, fails open).
-      await reportUsage(
-        buildUsage({
-          model: response.model,
-          usage: response.usage,
-          promptText,
-          completionText: typeof content === "string" ? content : "",
-          page,
-        })
-      );
-
       res.json({ content });
     } catch (error) {
+      // Budget guard / kill-switch blocked the call — surface its friendly reason.
+      if (error instanceof LLMBudgetError) {
+        return res.json({ content: error.message });
+      }
       console.error("AI Chat Error:", error);
       res.status(500).json({ error: "Failed to generate response" });
     }


### PR DESCRIPTION
## Summary
Opi felt thin because the chat endpoint ran a **bare 15-line persona with no knowledge injection**. This swaps it for core-server's `createSupportEngine` in marketing mode, so Opi now answers from the **shared Oplytics knowledge base**, is **page-aware**, and keeps **cost metering** — all handled inside the engine.

## Changes
- Add `@pablo2410/core-server@^0.3.0`; `/api/ai/chat` now calls `supportEngine.chat({ mode: "marketing", messages, context: { page } })`.
- The engine owns persona + knowledge retrieval + metering + budget guard, so the vendored persona and manual metering are gone (server bundle shrank ~9.5kb → 4kb).
- `aiUsageClient.ts` now exports `createLedgerHooks()` returning `{ onUsage, guard }` for the engine's `metering` option.
- Client sends `page` (current route) for page-aware answers.
- A budget/kill-switch block surfaces its friendly reason to the user instead of erroring.

## Knowledge depth
Today `^0.3.0` ships the 8-fact KB. When **core-server #7 (28-fact KB → `0.3.1`)** merges and publishes, the caret range picks it up at the next install/deploy — no further change here. So merge #7 first (or alongside) for the full effect.

## Tests
`tsc` clean; `vite build` + esbuild green.

## Note
The old vendored `server/llm.ts` is now unused (orphaned) — safe to delete in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)