### PR TITLE
fix(ai): boot-safe Opi config + surface real chat error

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -4,7 +4,12 @@ const envSchema = z.object({
   NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
   PORT: z.coerce.number().default(3000),
   FORGE_API_URL: z.string().url().optional(),
-  FORGE_API_KEY: z.string().min(1),
+  // Optional on purpose: in full-stack mode this same server also serves the
+  // marketing pages, so a missing key must NOT crash boot and black out the
+  // whole site. core-server's LLM client validates the key lazily at call time
+  // (not at construction), so Opi degrades to a friendly 500 while the site
+  // stays up.
+  FORGE_API_KEY: z.string().min(1).optional(),
   // AI usage ledger (Business Hub). Both optional — metering is skipped (fail-open)
   // until they're set, so the site runs fine without them.
   AI_USAGE_LEDGER_URL: z.string().url().optional(),

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,7 +13,7 @@ const __dirname = path.dirname(__filename);
 // knowledge base live in @pablo2410/core-server; metering + budget guard are
 // injected so every call is recorded and cost-controlled via the ledger.
 const supportEngine = createSupportEngine(
-  { forgeApiUrl: ENV.FORGE_API_URL ?? "", forgeApiKey: ENV.FORGE_API_KEY },
+  { forgeApiUrl: ENV.FORGE_API_URL ?? "", forgeApiKey: ENV.FORGE_API_KEY ?? "" },
   {
     knowledgeLimit: 6,
     metering: {
@@ -49,8 +49,12 @@ async function startServer() {
       if (error instanceof LLMBudgetError) {
         return res.json({ content: error.message });
       }
-      console.error("AI Chat Error:", error);
-      res.status(500).json({ error: "Failed to generate response" });
+      // Surface the real failure (core-server / Forge HTTP status + body, or
+      // the thrown message) in the response, not just the server logs — the
+      // engine's errors never include the API key.
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error("AI Chat Error:", detail);
+      res.status(500).json({ error: "Failed to generate response", detail });
     }
   });
 


### PR DESCRIPTION
## Context

Rebased onto **#84** (Opi now runs through `@pablo2410/core-server`'s shared support engine). That rewrite superseded most of this PR's original changes, so it's been reduced to the two things still relevant — both needed for the Manus full-stack cutover.

The live 500 root cause stands: the Manus deploy is **static-only**, so `server/index.ts` never runs. The actual fix is the full-stack (`web-db-user`) upgrade + setting `FORGE_API_KEY`. This PR makes that cutover safe and the endpoint debuggable.

## Changes

1. **Don't crash boot on missing `FORGE_API_KEY`** (`server/env.ts`) — in full-stack mode this server also serves the marketing pages, so a *required* key would black out the **whole site** on boot. Made optional. Verified core-server validates the key **lazily at call time** (`createLLMClient`'s `assertApiKey` only runs inside `invokeLLM`, not at `createSupportEngine` construction), so an empty key is boot-safe: site stays up, only Opi degrades to a friendly 500.
2. **Surface the real error** (`server/index.ts`) — pass `forgeApiKey ?? ""` (key is now optional) and return the thrown `detail` on the 500, so the core-server/Forge failure shows in the Network tab instead of only the server logs. The engine's errors never include the API key.

## Dropped from the original PR (now redundant after #84)

- `llm.ts` thinking-param removal — `llm.ts` is now dead code (no importers); the LLM call lives in core-server.
- `choices[0]` guard — core-server already does `result.choices[0]?.message?.content`.

## Deploy checklist (Manus side)

- [ ] Upgrade project to full-stack (`web-db-user`)
- [ ] Set `FORGE_API_KEY` env var (optional: `FORGE_API_URL`, `AI_USAGE_LEDGER_URL`, `AI_USAGE_INGEST_SECRET`)
- [ ] Allow outbound HTTPS to the Forge host
- [ ] Deploy + test Opi. If it still 500s, the Network response now shows the exact error.

## Verification

- `npm run check` (tsc --noEmit) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)