### PR TITLE
chore(deps): bump @pablo2410/core-server to ^0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
-    "@pablo2410/core-server": "^0.3.0",
+    "@pablo2410/core-server": "^0.4.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
       '@pablo2410/core-server':
-        specifier: ^0.3.0
-        version: 0.3.0(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
+        specifier: ^0.4.1
+        version: 0.4.1(@pablo2410/shared-ui@0.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
       '@pablo2410/shared-ui':
         specifier: 0.3.5
         version: 0.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
@@ -865,15 +865,18 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@pablo2410/core-server@0.3.0':
-    resolution: {integrity: sha512-jhbh6jpgiVmtJnMhml6qjuY2toZICmux9hbmpRENtKnpdK2loItJ3QBQpmi1zNtw4KWbGzn7P1JvGVxR63grHQ==}
+  '@pablo2410/core-server@0.4.1':
+    resolution: {integrity: sha512-/Xb5a45ksHtcObcLAbyIW50acYgtVcTKjsWsZvPZI1WDQb1kt7U2zJzQTW3HnosPww/DShQJza2oEIcR+D5pNg==}
     peerDependencies:
+      '@pablo2410/shared-ui': '>=0.7.0'
       '@trpc/server': '>=11.0.0'
       axios: '>=1.0.0'
       cookie: '>=0.6.0'
       express: '>=4.0.0'
       jose: '>=5.0.0'
     peerDependenciesMeta:
+      '@pablo2410/shared-ui':
+        optional: true
       axios:
         optional: true
       cookie:
@@ -4305,10 +4308,11 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@pablo2410/core-server@0.3.0(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
+  '@pablo2410/core-server@0.4.1(@pablo2410/shared-ui@0.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
     dependencies:
       '@trpc/server': 11.17.0(typescript@5.6.3)
     optionalDependencies:
+      '@pablo2410/shared-ui': 0.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
       axios: 1.13.6
       cookie: 0.7.2
       express: 4.22.1


### PR DESCRIPTION
## What

Bumps `@pablo2410/core-server` from `^0.3.0` → `^0.4.1` (+ lockfile).

## Why

The repo was pinned at `^0.3.0`, which for a `0.x` package caret-locks to `0.3.x` — so it would **never** auto-update to `0.4.1` on a build. Bumping the range pulls in:
- **Toned-down assistant persona** (core-server PR #9 — warm + professional, no "Alright mate" slang). This is the Phase 2 voice change.
- The expanded **Opi knowledge base** (8 → 28 grounded facts) from 0.4.x.

## Peer-dep note

pnpm warns that `core-server@0.4.1` wants peer `@pablo2410/shared-ui >=0.7.0` (we have `0.3.5`). **Benign for the Opi chat path** — `npm run check` (tsc) and `npm run build` both pass, because that path doesn't import the mismatched shared-ui types. Worth revisiting only if we later adopt core-server features that touch shared-ui.

## Verification
- `pnpm install` ✅ (resolves `0.4.1`)
- `npm run check` (tsc) ✅
- `npm run build` ✅

## Reminder: this alone won't change the live voice
The new persona only reaches production once the **Manus full-stack build runs this version through the core-server engine** (the Option A integration). The Cloudflare Pages deploy builds only the static frontend and doesn't run the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)