### PR TITLE
feat(demos): live Policy Deployment + SQDCP demos (auto-play tours, Testa data)

### DIFF
--- a/client/src/components/demos/PolicyDeploymentDemo.tsx
+++ b/client/src/components/demos/PolicyDeploymentDemo.tsx
@@ -1,15 +1,11 @@
 /**
- * Policy Deployment Demo — Real screenshot from portal.oplytics.digital
+ * Policy Deployment Demo — an auto-playing guided tour of the real product
+ * (oplytics-policy-deployment), framed in the app's own sidebar/header chrome.
+ * It walks Dashboard → X-Matrix → Catchball → Bowling, then settles on the live,
+ * clickable X-Matrix. Uses fictional Testa Group sample data; no auth, no backend.
  */
+import PolicyDeploymentTour from './policy/PolicyDeploymentTour';
+
 export default function PolicyDeploymentDemo() {
-  return (
-    <div className="w-full">
-      <img
-        src="https://d2xsxph8kpxj0f.cloudfront.net/310419663031899852/WWAck7XNk78XRtLpvPRn3L/Image31-03-2026at18.24_25a1d67b.png"
-        alt="Policy Deployment X-Matrix — The Vita Group — real data"
-        className="w-full h-auto block"
-        loading="lazy"
-      />
-    </div>
-  );
+  return <PolicyDeploymentTour />;
 }

--- a/client/src/components/demos/data/testaPolicyPlan.ts
+++ b/client/src/components/demos/data/testaPolicyPlan.ts
@@ -1,0 +1,231 @@
+/**
+ * Testa Group — fictional Policy Deployment sample data for the public marketing demo.
+ *
+ * IMPORTANT: This is 100% fictional. It must NOT contain any real customer or
+ * site names. It mirrors the *structure* of a real Hoshin Kanri X-Matrix so the
+ * demo looks dense and believable, with invented company, sites, owners, and figures.
+ *
+ * Shape matches what the ported Policy Deployment views consume (the context-resolved
+ * shape from oplytics-policy-deployment), using plain string ids instead of DB integers.
+ */
+
+export type SqdcpCategory = 'safety' | 'quality' | 'delivery' | 'cost' | 'people';
+export type ObjectiveStatus = 'on-track' | 'at-risk' | 'off-track' | 'not-started' | 'completed';
+export type CorrelationStrength = 'strong' | 'weak';
+export type CorrelationQuadrant = 'bo-ao' | 'ao-proj' | 'proj-kpi' | 'kpi-bo';
+export type KpiDirection = 'up' | 'down';
+
+export interface BreakthroughObjective {
+  id: string;
+  code: string;
+  description: string;
+  category: SqdcpCategory;
+}
+
+export interface AnnualObjective {
+  id: string;
+  code: string;
+  description: string;
+  owner: string;
+  status: ObjectiveStatus;
+}
+
+export interface Project {
+  id: string;
+  code: string;
+  name: string;
+  description: string;
+  owner: string;
+  status: ObjectiveStatus;
+  progress: number;
+  startDate: string;
+  endDate: string;
+  category: SqdcpCategory;
+}
+
+export interface Kpi {
+  id: string;
+  code: string;
+  name: string;
+  owner: string;
+  current: number;
+  target: number;
+  unit: string;
+  direction: KpiDirection;
+}
+
+export interface Correlation {
+  sourceId: string;
+  targetId: string;
+  strength: CorrelationStrength;
+  quadrant: CorrelationQuadrant;
+}
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  role: string;
+  department: string;
+}
+
+export interface BowlingEntry {
+  kpiId: string;
+  month: number; // 1-12
+  plan: number;
+  actual: number | null;
+}
+
+export interface PolicyPlan {
+  title: string;
+  owner: string;
+  lastUpdated: string;
+  year: number;
+  breakthroughObjectives: BreakthroughObjective[];
+  annualObjectives: AnnualObjective[];
+  projects: Project[];
+  kpis: Kpi[];
+  correlations: Correlation[];
+  teamMembers: TeamMember[];
+  bowlingChart: BowlingEntry[];
+}
+
+/* ── Breakthrough Objectives (3-year strategic) ── */
+const breakthroughObjectives: BreakthroughObjective[] = [
+  { id: 'bo-c1', code: 'C1', description: 'Reduce group-wide manufacturing waste by 40% across all sites', category: 'cost' },
+  { id: 'bo-s1', code: 'S1', description: 'Achieve zero lost-time incidents across the Components division', category: 'safety' },
+  { id: 'bo-d1', code: 'D1', description: 'Grow core revenue 25% through new European market penetration', category: 'delivery' },
+  { id: 'bo-q1', code: 'Q1', description: 'Achieve OEE >85% on all machining and cutting lines', category: 'quality' },
+  { id: 'bo-m1', code: 'M1', description: 'Build a continuous improvement culture with 80%+ engagement across all BUs', category: 'people' },
+];
+
+/* ── Annual Objectives (this-year tactics) ── */
+const annualObjectives: AnnualObjective[] = [
+  { id: 'ao-t1', code: 'T1', description: 'Reduce scrap rate from 8.2% to 5.5% at Hartwell & Brookline sites', owner: 'Helen Marsh', status: 'on-track' },
+  { id: 'ao-t2', code: 'T2', description: 'Implement standardised safety audits across all 9 Components sites', owner: 'Priya Nair', status: 'on-track' },
+  { id: 'ao-t3', code: 'T3', description: 'Launch production at Testa Valden to full capacity', owner: 'Marcus Cole', status: 'at-risk' },
+  { id: 'ao-t4', code: 'T4', description: 'Deploy OEE tracking on all machining cells across Norhaven & Calderport', owner: 'Daniel Roth', status: 'on-track' },
+  { id: 'ao-t5', code: 'T5', description: 'Reduce changeover time by 35% on cutting lines at Estmoor & Brookline', owner: 'Sofia Lindqvist', status: 'off-track' },
+  { id: 'ao-t6', code: 'T6', description: 'Roll out Testa CI Academy training programme to 200+ operators', owner: 'Owen Pryce', status: 'on-track' },
+];
+
+/* ── Improvement Projects ── */
+const projects: Project[] = [
+  { id: 'p-1-1', code: 'P1.1', name: 'Hartwell scrap reduction', description: 'Root-cause analysis and process parameter optimisation on HW-M1 and HW-M2 machining cells to reduce off-spec parts', owner: 'Helen Marsh', status: 'on-track', progress: 62, startDate: '2026-01-15', endDate: '2026-06-30', category: 'cost' },
+  { id: 'p-1-2', code: 'P1.2', name: 'Brookline conversion line waste mapping', description: 'Value-stream mapping of BL-CV1 and BL-CV2 conversion lines to identify and eliminate waste', owner: 'Tom Beckett', status: 'on-track', progress: 45, startDate: '2026-02-01', endDate: '2026-08-31', category: 'cost' },
+  { id: 'p-1-3', code: 'P1.3', name: 'Components safety audit programme', description: 'Design and deploy standardised safety audit checklists, near-miss reporting, and monthly review cadence across all 9 Components sites', owner: 'Priya Nair', status: 'at-risk', progress: 35, startDate: '2026-01-01', endDate: '2026-12-31', category: 'safety' },
+  { id: 'p-1-4', code: 'P1.4', name: 'Valden line ramp-up', description: 'Commission VA-L1 assembly line in Valden, train local operators, and achieve 80% utilisation within 6 months', owner: 'Marcus Cole', status: 'at-risk', progress: 28, startDate: '2026-03-01', endDate: '2026-09-30', category: 'delivery' },
+  { id: 'p-1-5', code: 'P1.5', name: 'OEE digital rollout — Norhaven & Calderport', description: 'Install OEE sensors and dashboards on NH-M1, NH-C1, and CP-M1 cells; integrate with Oplytics OEE Manager', owner: 'Daniel Roth', status: 'on-track', progress: 55, startDate: '2026-02-01', endDate: '2026-07-31', category: 'quality' },
+  { id: 'p-1-6', code: 'P1.6', name: 'SMED programme — Estmoor cutting lines', description: 'Apply Single-Minute Exchange of Dies methodology to ES-C1 and BL cutting lines to reduce changeover from 42 to 27 min', owner: 'Sofia Lindqvist', status: 'off-track', progress: 18, startDate: '2026-01-15', endDate: '2026-07-31', category: 'delivery' },
+  { id: 'p-1-7', code: 'P1.7', name: 'Testa CI Academy launch', description: 'Develop and deliver continuous improvement training modules (5S, problem solving, standard work) to 200+ operators across all business units', owner: 'Owen Pryce', status: 'on-track', progress: 40, startDate: '2026-02-01', endDate: '2026-11-30', category: 'people' },
+];
+
+/* ── KPIs ── */
+const kpis: Kpi[] = [
+  { id: 'k-1-1', code: 'IP1.1', name: 'Scrap rate (Hartwell)', owner: 'Helen Marsh', current: 7.1, target: 5.5, unit: '%', direction: 'down' },
+  { id: 'k-1-2', code: 'IP1.2', name: 'OEE — machining cells', owner: 'Daniel Roth', current: 72.4, target: 85, unit: '%', direction: 'up' },
+  { id: 'k-1-3', code: 'IP1.3', name: 'On-time delivery (Valden)', owner: 'Marcus Cole', current: 91.8, target: 97, unit: '%', direction: 'up' },
+  { id: 'k-1-4', code: 'IP1.4', name: 'Lost-time incidents (Components)', owner: 'Priya Nair', current: 3, target: 0, unit: 'incidents', direction: 'down' },
+  { id: 'k-1-5', code: 'IP1.5', name: 'Changeover time (Estmoor)', owner: 'Sofia Lindqvist', current: 42, target: 27, unit: 'minutes', direction: 'down' },
+  { id: 'k-1-6', code: 'IP1.6', name: 'Valden line utilisation', owner: 'Marcus Cole', current: 34, target: 80, unit: '%', direction: 'up' },
+  { id: 'k-1-7', code: 'IP1.7', name: 'CI Academy operators trained', owner: 'Owen Pryce', current: 48, target: 200, unit: 'people', direction: 'up' },
+];
+
+/* ── Team Members ── */
+const teamMembers: TeamMember[] = [
+  { id: 'tm-1', name: 'Dieter Falk', role: 'Programme Director', department: 'Strategy' },
+  { id: 'tm-2', name: 'Helen Marsh', role: 'Operations Lead', department: 'Components' },
+  { id: 'tm-3', name: 'Priya Nair', role: 'Safety Manager', department: 'HSE' },
+  { id: 'tm-4', name: 'Daniel Roth', role: 'CI Engineer', department: 'Engineering' },
+  { id: 'tm-5', name: 'Marcus Cole', role: 'Plant Manager', department: 'Valden' },
+  { id: 'tm-6', name: 'Sofia Lindqvist', role: 'Production Lead', department: 'Estmoor' },
+  { id: 'tm-7', name: 'Owen Pryce', role: 'L&D Lead', department: 'People' },
+];
+
+/* ── Correlations (X-Matrix links) ── */
+const correlations: Correlation[] = [
+  // Breakthrough Objective ↔ Annual Objective
+  { sourceId: 'bo-c1', targetId: 'ao-t1', strength: 'strong', quadrant: 'bo-ao' },
+  { sourceId: 'bo-c1', targetId: 'ao-t5', strength: 'weak', quadrant: 'bo-ao' },
+  { sourceId: 'bo-s1', targetId: 'ao-t2', strength: 'strong', quadrant: 'bo-ao' },
+  { sourceId: 'bo-d1', targetId: 'ao-t3', strength: 'strong', quadrant: 'bo-ao' },
+  { sourceId: 'bo-q1', targetId: 'ao-t4', strength: 'strong', quadrant: 'bo-ao' },
+  { sourceId: 'bo-q1', targetId: 'ao-t1', strength: 'weak', quadrant: 'bo-ao' },
+  { sourceId: 'bo-m1', targetId: 'ao-t6', strength: 'strong', quadrant: 'bo-ao' },
+  { sourceId: 'bo-m1', targetId: 'ao-t2', strength: 'weak', quadrant: 'bo-ao' },
+  // Annual Objective ↔ Project
+  { sourceId: 'ao-t1', targetId: 'p-1-1', strength: 'strong', quadrant: 'ao-proj' },
+  { sourceId: 'ao-t1', targetId: 'p-1-2', strength: 'strong', quadrant: 'ao-proj' },
+  { sourceId: 'ao-t2', targetId: 'p-1-3', strength: 'strong', quadrant: 'ao-proj' },
+  { sourceId: 'ao-t3', targetId: 'p-1-4', strength: 'strong', quadrant: 'ao-proj' },
+  { sourceId: 'ao-t4', targetId: 'p-1-5', strength: 'strong', quadrant: 'ao-proj' },
+  { sourceId: 'ao-t5', targetId: 'p-1-6', strength: 'strong', quadrant: 'ao-proj' },
+  { sourceId: 'ao-t6', targetId: 'p-1-7', strength: 'strong', quadrant: 'ao-proj' },
+  // Project ↔ KPI
+  { sourceId: 'p-1-1', targetId: 'k-1-1', strength: 'strong', quadrant: 'proj-kpi' },
+  { sourceId: 'p-1-2', targetId: 'k-1-1', strength: 'weak', quadrant: 'proj-kpi' },
+  { sourceId: 'p-1-3', targetId: 'k-1-4', strength: 'strong', quadrant: 'proj-kpi' },
+  { sourceId: 'p-1-4', targetId: 'k-1-6', strength: 'strong', quadrant: 'proj-kpi' },
+  { sourceId: 'p-1-4', targetId: 'k-1-3', strength: 'strong', quadrant: 'proj-kpi' },
+  { sourceId: 'p-1-5', targetId: 'k-1-2', strength: 'strong', quadrant: 'proj-kpi' },
+  { sourceId: 'p-1-6', targetId: 'k-1-5', strength: 'strong', quadrant: 'proj-kpi' },
+  { sourceId: 'p-1-7', targetId: 'k-1-7', strength: 'strong', quadrant: 'proj-kpi' },
+  // KPI ↔ Breakthrough Objective
+  { sourceId: 'k-1-1', targetId: 'bo-c1', strength: 'strong', quadrant: 'kpi-bo' },
+  { sourceId: 'k-1-2', targetId: 'bo-q1', strength: 'strong', quadrant: 'kpi-bo' },
+  { sourceId: 'k-1-3', targetId: 'bo-d1', strength: 'strong', quadrant: 'kpi-bo' },
+  { sourceId: 'k-1-4', targetId: 'bo-s1', strength: 'strong', quadrant: 'kpi-bo' },
+  { sourceId: 'k-1-5', targetId: 'bo-c1', strength: 'weak', quadrant: 'kpi-bo' },
+  { sourceId: 'k-1-6', targetId: 'bo-d1', strength: 'strong', quadrant: 'kpi-bo' },
+  { sourceId: 'k-1-7', targetId: 'bo-m1', strength: 'strong', quadrant: 'kpi-bo' },
+];
+
+/* ── Bowling chart (12-month plan vs actual per KPI) ──
+ * Deterministic so the demo renders identically every load. Plan trends linearly
+ * from a starting baseline to the target; the first 3 months carry actuals that
+ * trend toward each KPI's current value. */
+function round(value: number, dp: number): number {
+  const f = 10 ** dp;
+  return Math.round(value * f) / f;
+}
+
+function buildBowlingChart(): BowlingEntry[] {
+  const specs = [
+    { kpiId: 'k-1-1', start: 8.2, target: 5.5, currentVal: 7.1, dp: 1 },
+    { kpiId: 'k-1-2', start: 68, target: 85, currentVal: 72.4, dp: 1 },
+    { kpiId: 'k-1-3', start: 89, target: 97, currentVal: 91.8, dp: 1 },
+    { kpiId: 'k-1-4', start: 5, target: 0, currentVal: 3, dp: 0 },
+    { kpiId: 'k-1-5', start: 42, target: 27, currentVal: 39, dp: 0 },
+    { kpiId: 'k-1-6', start: 0, target: 80, currentVal: 34, dp: 0 },
+    { kpiId: 'k-1-7', start: 0, target: 200, currentVal: 48, dp: 0 },
+  ];
+  const ACTUAL_MONTHS = 3;
+  const entries: BowlingEntry[] = [];
+  for (const s of specs) {
+    for (let m = 1; m <= 12; m++) {
+      const plan = round(s.start + (s.target - s.start) * (m / 12), s.dp);
+      const actual = m <= ACTUAL_MONTHS
+        ? round(s.start + (s.currentVal - s.start) * (m / ACTUAL_MONTHS), s.dp)
+        : null;
+      entries.push({ kpiId: s.kpiId, month: m, plan, actual });
+    }
+  }
+  return entries;
+}
+
+const bowlingChart = buildBowlingChart();
+
+export const testaPolicyPlan: PolicyPlan = {
+  title: 'Testa Group — 3-Year Strategic Policy Deployment X-Matrix',
+  owner: 'Dieter Falk',
+  lastUpdated: '2026-03-22',
+  year: 2026,
+  breakthroughObjectives,
+  annualObjectives,
+  projects,
+  kpis,
+  correlations,
+  teamMembers,
+  bowlingChart,
+};
+
+export default testaPolicyPlan;

--- a/client/src/components/demos/index.ts
+++ b/client/src/components/demos/index.ts
@@ -25,3 +25,13 @@ export const demoComponents: Record<string, React.LazyExoticComponent<React.Comp
   'safety-manager': SafetyManagerDemo,
   'certification-manager': CertificationManagerDemo,
 };
+
+/**
+ * Slugs whose demo is a live, user-driven component (not a static screenshot or
+ * auto-playing animation). SolutionPage renders these WITHOUT the full-cover
+ * "Try It Live" overlay so the mouse can reach the demo; it shows a small,
+ * non-blocking corner CTA instead.
+ */
+export const interactiveDemos = new Set<string>([
+  'policy-deployment',
+]);

--- a/client/src/components/demos/policy/BowlingChartDemo.tsx
+++ b/client/src/components/demos/policy/BowlingChartDemo.tsx
@@ -1,0 +1,146 @@
+/*
+ * BowlingChartDemo — self-contained port of the real Policy Deployment Bowling Chart
+ * (oplytics-policy-deployment/client/src/components/BowlingChart.tsx). Fed injected
+ * fictional sample data instead of PolicyContext.
+ */
+import React from 'react';
+import { FileX2 } from 'lucide-react';
+import { testaPolicyPlan, type PolicyPlan, type KpiDirection } from '../data/testaPolicyPlan';
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const cellBorder = '1px solid #1e2738';
+const cellBg = '#0e1624';
+const headerBg = '#131b2e';
+
+function getCellStyle(plan: number, actual: number | null, direction: KpiDirection): { background: string; color: string } {
+  if (actual === null) return { background: cellBg, color: '#596475' };
+  if (direction === 'up') {
+    if (actual >= plan) return { background: 'rgba(16,185,129,0.15)', color: '#10b981' };
+    if (actual >= plan * 0.95) return { background: 'rgba(245,158,11,0.15)', color: '#f59e0b' };
+    return { background: 'rgba(239,68,68,0.15)', color: '#ef4444' };
+  } else {
+    if (actual <= plan) return { background: 'rgba(16,185,129,0.15)', color: '#10b981' };
+    if (actual <= plan * 1.05) return { background: 'rgba(245,158,11,0.15)', color: '#f59e0b' };
+    return { background: 'rgba(239,68,68,0.15)', color: '#ef4444' };
+  }
+}
+
+export default function BowlingChartDemo({ plan = testaPolicyPlan }: { plan?: PolicyPlan }) {
+  if (!plan) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <FileX2 className="w-12 h-12 mb-4" style={{ color: '#596475' }} />
+        <h2 className="text-lg font-semibold text-[#E2E8F0] mb-2">No Policy Plan</h2>
+        <p className="text-sm text-[#596475] max-w-md">No strategic policy plan exists for this enterprise yet.</p>
+      </div>
+    );
+  }
+
+  const { kpis, bowlingChart } = plan;
+
+  return (
+    <div className="w-full overflow-auto">
+      {/* Header — Oplytics purple gradient */}
+      <div className="px-6 py-3 rounded-t-md" style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}>
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-black text-white tracking-wide">Bowling Chart</h2>
+            <p className="text-sm text-white/60">Monthly target vs actual tracking</p>
+          </div>
+          <div className="text-right text-sm">
+            <div><span className="text-white/40">Owner:</span> <span className="font-medium text-white">{plan.owner}</span></div>
+            <div><span className="text-white/40">Last Update:</span> <span className="font-medium text-white">{plan.lastUpdated}</span></div>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-b-md overflow-auto" style={{ background: cellBg, border: cellBorder, borderTop: 'none' }}>
+        <table className="border-collapse w-full" style={{ minWidth: '1000px' }}>
+          <thead>
+            <tr>
+              <th className="px-2 py-2 text-left text-[11px] font-semibold w-8" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>#</th>
+              <th className="px-2 py-2 text-left text-[11px] font-semibold min-w-[180px]" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>Project/Deliverable</th>
+              <th className="px-2 py-2 text-left text-[11px] font-semibold w-24" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>Owner</th>
+              <th className="px-2 py-2 text-center text-[11px] font-semibold w-16" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>Initial</th>
+              <th className="px-2 py-2 text-center text-[11px] font-semibold w-14" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>Unit</th>
+              <th className="px-2 py-2 text-center text-[11px] font-semibold w-14" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>Plan/Act</th>
+              {MONTHS.map(m => (
+                <th key={m} className="px-1 py-2 text-center text-[11px] font-semibold w-12" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>{m}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {kpis.map((kpi, idx) => {
+              const entries = bowlingChart.filter(e => e.kpiId === kpi.id);
+
+              return (
+                <React.Fragment key={kpi.id}>
+                  {/* Plan row */}
+                  <tr>
+                    <td rowSpan={2} className="px-2 py-1 text-center text-xs font-bold" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>
+                      {idx + 1}
+                    </td>
+                    <td rowSpan={2} className="px-2 py-1 text-xs font-medium" style={{ background: headerBg, border: cellBorder, color: '#c0c6d0' }}>
+                      {kpi.name}
+                    </td>
+                    <td rowSpan={2} className="px-2 py-1 text-xs" style={{ background: headerBg, border: cellBorder, color: '#8890a0' }}>
+                      {kpi.owner}
+                    </td>
+                    <td rowSpan={2} className="px-2 py-1 text-center text-xs font-mono font-medium" style={{ background: headerBg, border: cellBorder, color: '#8890a0' }}>
+                      {kpi.current}
+                    </td>
+                    <td rowSpan={2} className="px-2 py-1 text-center text-xs" style={{ background: headerBg, border: cellBorder, color: '#596475' }}>
+                      {kpi.unit}
+                    </td>
+                    <td className="px-1 py-1 text-center text-[10px] font-semibold" style={{ background: 'rgba(140,52,233,0.08)', border: cellBorder, color: '#8C34E9' }}>
+                      Plan
+                    </td>
+                    {MONTHS.map((_, mIdx) => {
+                      const entry = entries.find(e => e.month === mIdx + 1);
+                      return (
+                        <td key={mIdx} className="px-1 py-1 text-center text-[11px] font-mono" style={{ background: 'rgba(140,52,233,0.04)', border: cellBorder, color: '#8890a0' }}>
+                          {entry ? (typeof entry.plan === 'number' ? entry.plan : '') : ''}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                  {/* Actual row */}
+                  <tr>
+                    <td className="px-1 py-1 text-center text-[10px] font-semibold" style={{ background: cellBg, border: cellBorder, color: '#596475' }}>
+                      Act
+                    </td>
+                    {MONTHS.map((_, mIdx) => {
+                      const entry = entries.find(e => e.month === mIdx + 1);
+                      const style = entry ? getCellStyle(entry.plan, entry.actual, kpi.direction) : { background: cellBg, color: '#596475' };
+                      return (
+                        <td key={mIdx} className="px-1 py-1 text-center text-[11px] font-mono font-medium" style={{ ...style, border: cellBorder }}>
+                          {entry?.actual !== null && entry?.actual !== undefined ? entry.actual : ''}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-6 mt-3 px-2 pb-1 flex-wrap">
+        <div className="flex items-center gap-1.5">
+          <div className="w-4 h-3 rounded-sm" style={{ background: 'rgba(16,185,129,0.15)', border: '1px solid rgba(16,185,129,0.3)' }} />
+          <span className="text-xs" style={{ color: '#596475' }}>On/above target</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-4 h-3 rounded-sm" style={{ background: 'rgba(245,158,11,0.15)', border: '1px solid rgba(245,158,11,0.3)' }} />
+          <span className="text-xs" style={{ color: '#596475' }}>Near target</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-4 h-3 rounded-sm" style={{ background: 'rgba(239,68,68,0.15)', border: '1px solid rgba(239,68,68,0.3)' }} />
+          <span className="text-xs" style={{ color: '#596475' }}>Below target</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/demos/policy/CatchballDemo.tsx
+++ b/client/src/components/demos/policy/CatchballDemo.tsx
@@ -1,0 +1,191 @@
+/*
+ * CatchballDemo — self-contained port of the real Policy Deployment Catchball /
+ * Goal Cascade view (oplytics-policy-deployment/client/src/components/Catchball.tsx).
+ * Fed injected fictional sample data instead of PolicyContext.
+ */
+import { ChevronRight, Target, Crosshair, FolderKanban, BarChart3, ArrowDown, FileX2 } from 'lucide-react';
+import { getCategoryColor } from '../xmatrix/xmatrixTokens';
+import { testaPolicyPlan, type PolicyPlan } from '../data/testaPolicyPlan';
+
+export default function CatchballDemo({ plan = testaPolicyPlan }: { plan?: PolicyPlan }) {
+  if (!plan) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <FileX2 className="w-12 h-12 mb-4" style={{ color: '#596475' }} />
+        <h2 className="text-lg font-semibold text-[#E2E8F0] mb-2">No Policy Plan</h2>
+        <p className="text-sm text-[#596475] max-w-md">No strategic policy plan exists for this enterprise yet.</p>
+      </div>
+    );
+  }
+
+  const { breakthroughObjectives: bos, annualObjectives: aos, projects, kpis, correlations } = plan;
+
+  const getLinkedAOs = (boId: string) => {
+    const aoIds = correlations
+      .filter(c => (c.sourceId === boId || c.targetId === boId) && c.quadrant === 'bo-ao')
+      .map(c => c.sourceId === boId ? c.targetId : c.sourceId);
+    return aos.filter(ao => aoIds.includes(ao.id));
+  };
+
+  const getLinkedProjects = (aoId: string) => {
+    const projIds = correlations
+      .filter(c => (c.sourceId === aoId || c.targetId === aoId) && c.quadrant === 'ao-proj')
+      .map(c => c.sourceId === aoId ? c.targetId : c.sourceId);
+    return projects.filter(p => projIds.includes(p.id));
+  };
+
+  const getLinkedKPIs = (projId: string) => {
+    const kpiIds = correlations
+      .filter(c => c.sourceId === projId && c.quadrant === 'proj-kpi')
+      .map(c => c.targetId);
+    return kpis.filter(k => kpiIds.includes(k.id));
+  };
+
+  const statusColors: Record<string, string> = {
+    'on-track': '#10b981',
+    'at-risk': '#f59e0b',
+    'off-track': '#ef4444',
+    'not-started': '#596475',
+    'completed': '#10b981',
+  };
+
+  return (
+    <div className="w-full">
+      {/* Header — Oplytics purple gradient */}
+      <div className="px-6 py-3 rounded-t-md" style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}>
+        <h2 className="text-lg font-black text-white tracking-wide">Catchball / Goal Cascade</h2>
+        <p className="text-sm text-white/60">Strategic alignment from breakthrough objectives to projects and KPIs</p>
+      </div>
+
+      <div className="rounded-b-md p-6" style={{ background: '#0e1624', border: '1px solid #1e2738', borderTop: 'none' }}>
+        {/* Level indicators */}
+        <div className="flex items-center gap-3 mb-6 pb-4 flex-wrap" style={{ borderBottom: '1px solid #1e2738' }}>
+          <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-md" style={{ background: 'rgba(140,52,233,0.12)' }}>
+            <Target className="w-4 h-4" style={{ color: '#8C34E9' }} />
+            <span className="text-xs font-bold" style={{ color: '#8C34E9' }}>Breakthrough Objectives</span>
+          </div>
+          <ChevronRight className="w-4 h-4" style={{ color: '#2e3a4e' }} />
+          <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-md" style={{ background: 'rgba(29,184,206,0.1)' }}>
+            <Crosshair className="w-4 h-4" style={{ color: '#1DB8CE' }} />
+            <span className="text-xs font-bold" style={{ color: '#1DB8CE' }}>Annual Tactics</span>
+          </div>
+          <ChevronRight className="w-4 h-4" style={{ color: '#2e3a4e' }} />
+          <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-md" style={{ background: 'rgba(249,115,22,0.1)' }}>
+            <FolderKanban className="w-4 h-4" style={{ color: '#f97316' }} />
+            <span className="text-xs font-bold" style={{ color: '#f97316' }}>Projects</span>
+          </div>
+          <ChevronRight className="w-4 h-4" style={{ color: '#2e3a4e' }} />
+          <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-md" style={{ background: 'rgba(59,130,246,0.1)' }}>
+            <BarChart3 className="w-4 h-4" style={{ color: '#3b82f6' }} />
+            <span className="text-xs font-bold" style={{ color: '#3b82f6' }}>KPIs</span>
+          </div>
+        </div>
+
+        {/* Cascade tree */}
+        <div className="space-y-5">
+          {bos.map(bo => {
+            const linkedAOs = getLinkedAOs(bo.id);
+            return (
+              <div key={bo.id} className="rounded-md overflow-hidden" style={{ border: '1px solid #1e2738' }}>
+                {/* BO Level */}
+                <div className="px-4 py-3" style={{ background: 'rgba(140,52,233,0.06)', borderBottom: '1px solid #1e2738' }}>
+                  <div className="flex items-center gap-2">
+                    <Target className="w-5 h-5" style={{ color: '#8C34E9' }} />
+                    <span className="font-mono text-xs font-bold" style={{ color: '#8C34E9' }}>{bo.code}</span>
+                    <span className="text-sm font-semibold text-white">{bo.description}</span>
+                    {linkedAOs.length === 0 && (
+                      <span className="text-xs text-red-400">Cascade required</span>
+                    )}
+                    <span className="ml-auto text-[10px] font-semibold px-2 py-0.5 rounded uppercase" style={{ background: 'rgba(140,52,233,0.12)', color: '#8C34E9' }}>
+                      {bo.category}
+                    </span>
+                  </div>
+                </div>
+
+                {/* AO Level */}
+                {linkedAOs.length > 0 && (
+                  <div className="pl-6">
+                    {linkedAOs.map((ao, aoIdx) => {
+                      const linkedProjects = getLinkedProjects(ao.id);
+                      return (
+                        <div key={ao.id} style={{ borderBottom: aoIdx < linkedAOs.length - 1 ? '1px solid #1a2233' : 'none' }}>
+                          <div className="flex items-center gap-2 px-4 py-2.5" style={{ background: 'rgba(29,184,206,0.04)' }}>
+                            <ArrowDown className="w-3 h-3 -ml-3" style={{ color: '#2e3a4e' }} />
+                            <Crosshair className="w-4 h-4" style={{ color: '#1DB8CE' }} />
+                            <span className="font-mono text-[10px] font-bold" style={{ color: '#1DB8CE' }}>{ao.code}</span>
+                            <span className="text-xs font-medium" style={{ color: '#c0c6d0' }}>{ao.description}</span>
+                            {linkedProjects.length === 0 && (
+                              <span className="text-xs text-red-400">Cascade required</span>
+                            )}
+                            <div className="w-2 h-2 rounded-full ml-auto" style={{ background: statusColors[ao.status] || '#596475' }} title={ao.status} />
+                            <span className="text-[10px]" style={{ color: '#596475' }}>{ao.owner}</span>
+                          </div>
+
+                          {/* Project Level */}
+                          {linkedProjects.length > 0 && (
+                            <div className="pl-8">
+                              {linkedProjects.map((proj, pIdx) => {
+                                const linkedKPIs = getLinkedKPIs(proj.id);
+                                return (
+                                  <div key={proj.id} style={{ borderBottom: pIdx < linkedProjects.length - 1 ? '1px solid #151d2e' : 'none' }}>
+                                    <div className="flex items-center gap-2 px-4 py-2" style={{ background: 'rgba(249,115,22,0.03)' }}>
+                                      <ArrowDown className="w-3 h-3 -ml-3" style={{ color: '#1e2738' }} />
+                                      <FolderKanban className="w-3.5 h-3.5" style={{ color: getCategoryColor(proj.category) }} />
+                                      <span className="font-mono text-[10px] font-bold" style={{ color: '#596475' }}>{proj.code}</span>
+                                      <span className="text-xs" style={{ color: '#c0c6d0' }}>{proj.name}</span>
+                                      <div className="flex items-center gap-1 ml-auto">
+                                        <div className="w-16 h-1.5 rounded-full overflow-hidden" style={{ background: '#1e2738' }}>
+                                          <div
+                                            className="h-full rounded-full"
+                                            style={{
+                                              width: `${proj.progress}%`,
+                                              backgroundColor: getCategoryColor(proj.category),
+                                            }}
+                                          />
+                                        </div>
+                                        <span className="text-[10px] font-mono" style={{ color: '#596475' }}>{proj.progress}%</span>
+                                        <div className="w-2 h-2 rounded-full" style={{ background: statusColors[proj.status] || '#596475' }} title={proj.status} />
+                                      </div>
+                                    </div>
+
+                                    {/* KPI Level */}
+                                    {linkedKPIs.length > 0 && (
+                                      <div className="pl-10" style={{ background: 'rgba(59,130,246,0.03)' }}>
+                                        {linkedKPIs.map(kpi => {
+                                          const pct = kpi.direction === 'up'
+                                            ? Math.min(100, (kpi.current / kpi.target) * 100)
+                                            : Math.min(100, (kpi.target / Math.max(kpi.current, 1)) * 100);
+                                          return (
+                                            <div key={kpi.id} className="flex items-center gap-2 px-4 py-1.5">
+                                              <BarChart3 className="w-3 h-3" style={{ color: '#3b82f6' }} />
+                                              <span className="font-mono text-[10px]" style={{ color: '#3b82f6' }}>{kpi.code}</span>
+                                              <span className="text-[11px]" style={{ color: '#8890a0' }}>{kpi.name}</span>
+                                              <div className="flex items-center gap-1 ml-auto">
+                                                <span className="text-[10px] font-mono font-medium" style={{ color: '#c0c6d0' }}>
+                                                  {kpi.current} / {kpi.target} {kpi.unit}
+                                                </span>
+                                                <div className="w-2 h-2 rounded-full" style={{ background: pct >= 90 ? '#10b981' : pct >= 70 ? '#f59e0b' : '#ef4444' }} />
+                                              </div>
+                                            </div>
+                                          );
+                                        })}
+                                      </div>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/demos/policy/PolicyDashboardDemo.tsx
+++ b/client/src/components/demos/policy/PolicyDashboardDemo.tsx
@@ -1,0 +1,193 @@
+/*
+ * PolicyDashboardDemo — self-contained port of the real Policy Deployment Dashboard
+ * (oplytics-policy-deployment/client/src/components/Dashboard.tsx). Fed injected
+ * fictional sample data instead of PolicyContext.
+ */
+import { Target, Users, FolderKanban, BarChart3, FileX2 } from 'lucide-react';
+import { getStatusColor } from '../xmatrix/xmatrixTokens';
+import { testaPolicyPlan, type PolicyPlan, type Kpi } from '../data/testaPolicyPlan';
+
+function KPIGauge({ kpi }: { kpi: Kpi }) {
+  const pct = kpi.direction === 'up'
+    ? Math.min(100, (kpi.current / kpi.target) * 100)
+    : kpi.current === 0 ? 100 : Math.min(100, (kpi.target / kpi.current) * 100);
+  const color = pct >= 90 ? '#1DB8CE' : pct >= 70 ? '#f59e0b' : '#ef4444';
+  const circumference = 2 * Math.PI * 36;
+  const dashOffset = circumference - (pct / 100) * circumference;
+
+  return (
+    <div className="flex flex-col items-center p-3">
+      <div className="relative w-20 h-20">
+        <svg className="w-20 h-20 -rotate-90" viewBox="0 0 80 80">
+          <circle cx="40" cy="40" r="36" fill="none" stroke="#1e2738" strokeWidth="6" />
+          <circle
+            cx="40" cy="40" r="36" fill="none"
+            stroke={color} strokeWidth="6"
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+            strokeLinecap="round"
+            className="transition-all duration-700"
+          />
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-sm font-bold text-white">{Math.round(pct)}%</span>
+        </div>
+      </div>
+      <span className="text-[11px] font-medium text-gray-300 mt-1.5 text-center leading-tight">{kpi.name}</span>
+      <span className="text-[10px] mt-0.5" style={{ color: '#596475' }}>
+        {kpi.current} / {kpi.target} {kpi.unit}
+      </span>
+    </div>
+  );
+}
+
+export default function PolicyDashboardDemo({ plan = testaPolicyPlan }: { plan?: PolicyPlan }) {
+  if (!plan) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <FileX2 className="w-12 h-12 mb-4" style={{ color: '#596475' }} />
+        <h2 className="text-lg font-semibold text-[#E2E8F0] mb-2">No Policy Plan</h2>
+        <p className="text-sm text-[#596475] max-w-md">No strategic policy plan exists for this enterprise yet.</p>
+      </div>
+    );
+  }
+
+  const { projects, kpis, breakthroughObjectives: bos, teamMembers } = plan;
+
+  const statusCounts = {
+    'on-track': projects.filter(p => p.status === 'on-track').length,
+    'at-risk': projects.filter(p => p.status === 'at-risk').length,
+    'off-track': projects.filter(p => p.status === 'off-track').length,
+    'not-started': projects.filter(p => p.status === 'not-started').length,
+  };
+
+  const avgProgress = Math.round(projects.reduce((sum, p) => sum + p.progress, 0) / projects.length);
+
+  const kpisOnTrack = kpis.filter(k => {
+    const pct = k.direction === 'up'
+      ? (k.current / k.target) * 100
+      : k.current === 0 ? 100 : (k.target / k.current) * 100;
+    return pct >= 90;
+  }).length;
+
+  const cardStyle = { background: '#0e1624', border: '1px solid #1e2738' };
+  const cardHeaderStyle = { borderBottom: '1px solid #1e2738' };
+
+  return (
+    <div className="w-full space-y-6">
+      {/* Hero Section — Oplytics purple gradient */}
+      <div className="relative rounded-md overflow-hidden" style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 50%, #1a1040 100%)' }}>
+        <div className="absolute inset-0 opacity-10" style={{ backgroundImage: 'radial-gradient(circle at 70% 30%, rgba(29,184,206,0.3) 0%, transparent 60%)' }} />
+        <div className="relative px-6 py-8">
+          <p className="text-[10px] uppercase tracking-[0.2em] mb-2" style={{ color: 'rgba(255,255,255,0.5)' }}>
+            ■ Strategy Deployment
+          </p>
+          <h2 className="text-lg font-black text-white tracking-wide">{plan.title}</h2>
+          <p className="text-white/50 mt-1 text-sm">Strategic deployment overview for {plan.year}</p>
+          <div className="flex items-center gap-4 mt-5 flex-wrap">
+            {[
+              { value: `${avgProgress}%`, label: 'Avg Progress' },
+              { value: projects.length, label: 'Projects' },
+              { value: `${kpisOnTrack}/${kpis.length}`, label: 'KPIs On Track' },
+              { value: bos.length, label: 'Breakthrough Obj.' },
+            ].map((stat, i) => (
+              <div key={i} className="rounded-md px-4 py-2.5" style={{ background: 'rgba(255,255,255,0.08)', backdropFilter: 'blur(8px)', border: '1px solid rgba(255,255,255,0.1)' }}>
+                <div className="text-2xl font-bold text-white">{stat.value}</div>
+                <div className="text-[10px] uppercase tracking-wider" style={{ color: 'rgba(255,255,255,0.5)' }}>{stat.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        {/* Project Status */}
+        <div className="rounded-md overflow-hidden" style={cardStyle}>
+          <div className="px-4 py-3 flex items-center gap-2" style={cardHeaderStyle}>
+            <FolderKanban className="w-4 h-4" style={{ color: '#8C34E9' }} />
+            <h3 className="text-sm font-bold text-white">Project Status</h3>
+          </div>
+          <div className="p-4 space-y-3">
+            {Object.entries(statusCounts).map(([status, count]) => (
+              <div key={status} className="flex items-center gap-3">
+                <div className="w-3 h-3 rounded-full" style={{ backgroundColor: getStatusColor(status) }} />
+                <span className="text-xs capitalize flex-1" style={{ color: '#8890a0' }}>{status.replace('-', ' ')}</span>
+                <span className="text-sm font-bold text-white">{count}</span>
+                <div className="w-20 h-1.5 rounded-full overflow-hidden" style={{ background: '#1e2738' }}>
+                  <div
+                    className="h-full rounded-full transition-all"
+                    style={{
+                      width: `${(count / projects.length) * 100}%`,
+                      backgroundColor: getStatusColor(status),
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* KPI Gauges */}
+        <div className="lg:col-span-2 rounded-md overflow-hidden" style={cardStyle}>
+          <div className="px-4 py-3 flex items-center gap-2" style={cardHeaderStyle}>
+            <BarChart3 className="w-4 h-4" style={{ color: '#1DB8CE' }} />
+            <h3 className="text-sm font-bold text-white">Key Performance Indicators</h3>
+          </div>
+          <div className="p-2 flex flex-wrap justify-center">
+            {kpis.map(kpi => (
+              <KPIGauge key={kpi.id} kpi={kpi} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom row */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        {/* Breakthrough Objectives */}
+        <div className="rounded-md overflow-hidden" style={cardStyle}>
+          <div className="px-4 py-3 flex items-center gap-2" style={cardHeaderStyle}>
+            <Target className="w-4 h-4" style={{ color: '#8C34E9' }} />
+            <h3 className="text-sm font-bold text-white">Breakthrough Objectives (3-5 Year)</h3>
+          </div>
+          <div className="p-4 space-y-2">
+            {bos.map(bo => (
+              <div key={bo.id} className="flex items-center gap-3 px-3 py-2 rounded-md" style={{ background: '#131b2e' }}>
+                <span className="font-mono text-[10px] font-bold" style={{ color: '#8C34E9' }}>{bo.code}</span>
+                <span className="text-xs text-gray-300 flex-1">{bo.description}</span>
+                <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded uppercase" style={{ background: 'rgba(140,52,233,0.12)', color: '#8C34E9' }}>
+                  {bo.category}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Team */}
+        <div className="rounded-md overflow-hidden" style={cardStyle}>
+          <div className="px-4 py-3 flex items-center gap-2" style={cardHeaderStyle}>
+            <Users className="w-4 h-4" style={{ color: '#1DB8CE' }} />
+            <h3 className="text-sm font-bold text-white">Team Members</h3>
+          </div>
+          <div className="p-4 space-y-2">
+            {teamMembers.map(member => (
+              <div key={member.id} className="flex items-center gap-3 px-3 py-2 rounded-md" style={{ background: '#131b2e' }}>
+                <div className="w-8 h-8 rounded-full flex items-center justify-center" style={{ background: 'rgba(140,52,233,0.15)' }}>
+                  <span className="text-xs font-bold" style={{ color: '#8C34E9' }}>
+                    {member.name.split(' ').map(n => n[0]).join('')}
+                  </span>
+                </div>
+                <div className="flex-1">
+                  <div className="text-xs font-semibold text-white">{member.name}</div>
+                  <div className="text-[10px]" style={{ color: '#596475' }}>{member.role}</div>
+                </div>
+                <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: '#1e2738', color: '#596475' }}>
+                  {member.department}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/demos/policy/PolicyDeploymentTour.tsx
+++ b/client/src/components/demos/policy/PolicyDeploymentTour.tsx
@@ -1,0 +1,264 @@
+/*
+ * PolicyDeploymentTour — a self-contained, auto-playing walkthrough of the Policy
+ * Deployment app, framed in a faithful (lightweight) copy of the product's own
+ * sidebar + header chrome (no fake browser window).
+ *
+ * Tour: opens on the Dashboard, then an animated cursor "clicks" through the
+ * sidebar — X-Matrix → Catchball (Cascade) → Bowling Chart — and finally settles
+ * on the X-Matrix, which is left live and clickable. The sidebar stays interactive
+ * throughout, and a Replay control restarts the tour.
+ *
+ * All views are ports of the real components, fed fictional Testa Group sample data.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  PanelLeft, FileStack, ArrowLeft, LayoutGrid, Grid3X3, BarChart3,
+  FolderKanban, GitBranchPlus, Target, Play, Pause, RotateCcw,
+  ChevronRight, MousePointer2, Settings,
+} from 'lucide-react';
+import XMatrixDemo from '../xmatrix/XMatrixDemo';
+import PolicyDashboardDemo from './PolicyDashboardDemo';
+import BowlingChartDemo from './BowlingChartDemo';
+import CatchballDemo from './CatchballDemo';
+
+type View = 'dashboard' | 'xmatrix' | 'bowling' | 'actions' | 'catchball' | 'deployments';
+
+const MENU: { view: View; label: string; icon: typeof LayoutGrid }[] = [
+  { view: 'dashboard', label: 'Dashboard', icon: LayoutGrid },
+  { view: 'xmatrix', label: 'X-Matrix', icon: Grid3X3 },
+  { view: 'bowling', label: 'Bowling Chart', icon: BarChart3 },
+  { view: 'actions', label: 'Action Plans', icon: FolderKanban },
+  { view: 'catchball', label: 'Catchball', icon: GitBranchPlus },
+  { view: 'deployments', label: 'Deployments', icon: Target },
+];
+
+/** The auto-play sequence — settles back on the X-Matrix, left interactive. */
+const TOUR: View[] = ['dashboard', 'xmatrix', 'catchball', 'bowling', 'xmatrix'];
+
+const labelFor = (view: View) => MENU.find(m => m.view === view)?.label ?? view;
+
+function PlaceholderView({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="rounded-md p-10 text-center" style={{ background: '#0e1624', border: '1px solid #1e2738' }}>
+      <h2 className="text-lg font-black text-white tracking-wide mb-2">{title}</h2>
+      <p className="text-sm max-w-md mx-auto" style={{ color: '#596475' }}>{description}</p>
+    </div>
+  );
+}
+
+export default function PolicyDeploymentTour() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  const [activeView, setActiveView] = useState<View>('dashboard');
+  const [stepIndex, setStepIndex] = useState(0);
+  const [playing, setPlaying] = useState(true);
+  const [done, setDone] = useState(false);
+  const [cursor, setCursor] = useState<{ x: number; y: number }>({ x: 24, y: 150 });
+  const [clicking, setClicking] = useState(false);
+
+  const moveCursorToView = useCallback((view: View) => {
+    const item = itemRefs.current[view];
+    const container = containerRef.current;
+    if (!item || !container) return;
+    const ir = item.getBoundingClientRect();
+    const cr = container.getBoundingClientRect();
+    setCursor({ x: ir.left - cr.left + 26, y: ir.top - cr.top + ir.height / 2 });
+  }, []);
+
+  // Rest the cursor on the starting item once mounted.
+  useEffect(() => {
+    moveCursorToView('dashboard');
+  }, [moveCursorToView]);
+
+  // Auto-play driver: schedule the move to the next tour stop.
+  useEffect(() => {
+    if (!playing || done) return;
+    if (stepIndex >= TOUR.length - 1) {
+      setDone(true); // reached the X-Matrix — leave it live
+      return;
+    }
+    const nextView = TOUR[stepIndex + 1];
+    const dwell = stepIndex === 0 ? 2800 : 3400; // look at the current view first
+    const travel = 850;
+
+    const tMove = setTimeout(() => moveCursorToView(nextView), dwell);
+    const tClick = setTimeout(() => setClicking(true), dwell + travel);
+    const tSwitch = setTimeout(() => {
+      setClicking(false);
+      setActiveView(nextView);
+      setStepIndex(i => i + 1);
+    }, dwell + travel + 360);
+
+    return () => {
+      clearTimeout(tMove);
+      clearTimeout(tClick);
+      clearTimeout(tSwitch);
+    };
+  }, [stepIndex, playing, done, moveCursorToView]);
+
+  const startTour = () => {
+    setDone(false);
+    setStepIndex(0);
+    setActiveView('dashboard');
+    setPlaying(true);
+    moveCursorToView('dashboard');
+  };
+
+  const selectView = (view: View) => {
+    // Manual navigation hands control to the user and ends the tour.
+    setPlaying(false);
+    setDone(true);
+    setClicking(false);
+    setActiveView(view);
+  };
+
+  const renderView = (view: View) => {
+    switch (view) {
+      case 'dashboard': return <PolicyDashboardDemo />;
+      case 'xmatrix': return <XMatrixDemo interactive={done} />;
+      case 'bowling': return <BowlingChartDemo />;
+      case 'catchball': return <CatchballDemo />;
+      case 'actions': return <PlaceholderView title="Action Plans" description="Track and assign the improvement actions that drive each project. Open the full app to manage the live action register." />;
+      case 'deployments': return <PlaceholderView title="Deployments" description="Cascade objectives to individual sites with SQDCP targets. Open the full app to view live site deployments." />;
+    }
+  };
+
+  const showCursor = playing && !done;
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative flex w-full select-none overflow-hidden"
+      style={{ background: '#0a0e1a', minHeight: 620 }}
+    >
+      {/* ── Sidebar ── */}
+      <aside className="shrink-0 w-[210px] flex flex-col" style={{ background: '#0b1018', borderRight: '1px solid #1e2738' }}>
+        {/* Sidebar header */}
+        <div className="h-14 flex items-center gap-2 px-3" style={{ borderBottom: '1px solid #1e2738' }}>
+          <PanelLeft className="h-4 w-4" style={{ color: '#596475' }} />
+          <FileStack className="h-4 w-4" style={{ color: '#8C34E9' }} />
+          <span className="text-sm font-semibold text-white truncate">Policy Deployment</span>
+        </div>
+
+        <div className="flex-1 py-2 overflow-y-auto">
+          {/* Service Hub */}
+          <div className="px-2">
+            <div className="flex items-center gap-2 h-9 px-3 rounded-md text-xs" style={{ color: '#596475' }}>
+              <ArrowLeft className="h-4 w-4" />
+              <span>Service Hub</span>
+            </div>
+          </div>
+
+          {/* Analysis section */}
+          <div className="px-4 pt-3 pb-1">
+            <span className="text-[10px] font-medium uppercase tracking-wider" style={{ color: '#596475' }}>Analysis</span>
+          </div>
+          <nav className="px-2 space-y-0.5">
+            {MENU.map(item => {
+              const isActive = activeView === item.view;
+              const Icon = item.icon;
+              return (
+                <button
+                  key={item.view}
+                  ref={el => { itemRefs.current[item.view] = el; }}
+                  onClick={() => selectView(item.view)}
+                  className="w-full flex items-center gap-2.5 h-9 px-3 rounded-md text-[13px] transition-colors"
+                  style={{
+                    background: isActive ? 'rgba(140,52,233,0.12)' : 'transparent',
+                    color: isActive ? '#fff' : '#8890a0',
+                  }}
+                  onMouseEnter={e => { if (!isActive) (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)'; }}
+                  onMouseLeave={e => { if (!isActive) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                >
+                  <Icon className="h-4 w-4" style={{ color: isActive ? '#8C34E9' : '#596475' }} />
+                  <span className="truncate">{item.label}</span>
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+
+        {/* Sidebar footer */}
+        <div className="p-2" style={{ borderTop: '1px solid #1e2738' }}>
+          <div className="flex items-center gap-2.5 h-9 px-3 rounded-md text-[13px]" style={{ color: '#596475' }}>
+            <Settings className="h-4 w-4" />
+            <span>Settings</span>
+          </div>
+        </div>
+      </aside>
+
+      {/* ── Main panel ── */}
+      <div className="flex-1 min-w-0 flex flex-col">
+        {/* Header / breadcrumb */}
+        <header className="h-14 flex items-center justify-between gap-3 px-4" style={{ borderBottom: '1px solid #1e2738' }}>
+          <div className="flex items-center gap-2 min-w-0 text-sm">
+            <FileStack className="h-4 w-4 shrink-0" style={{ color: '#8C34E9' }} />
+            <span className="font-semibold text-white">Policy Deployment</span>
+            <ChevronRight className="h-3.5 w-3.5 shrink-0" style={{ color: '#2e3a4e' }} />
+            <span className="truncate" style={{ color: '#8890a0' }}>{labelFor(activeView)}</span>
+            <span className="hidden sm:inline-flex items-center gap-1.5 ml-1 px-2 py-0.5 rounded-md text-[11px] font-medium"
+              style={{ background: 'rgba(140,52,233,0.1)', color: '#C084FC', border: '1px solid rgba(140,52,233,0.2)' }}>
+              <span className="w-3.5 h-3.5 rounded-sm flex items-center justify-center text-[8px] font-bold" style={{ background: '#8C34E9', color: '#fff' }}>TG</span>
+              Testa Group
+            </span>
+          </div>
+
+          {/* Tour controls */}
+          <div className="flex items-center gap-2 shrink-0">
+            {!done && (
+              <div className="hidden sm:flex items-center gap-1.5 mr-1">
+                {TOUR.map((_, i) => (
+                  <span key={i} className="w-1.5 h-1.5 rounded-full transition-colors"
+                    style={{ background: i <= stepIndex ? '#8C34E9' : '#1e2738' }} />
+                ))}
+              </div>
+            )}
+            {!done ? (
+              <button
+                onClick={() => setPlaying(p => !p)}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-[11px] font-semibold transition-colors"
+                style={{ background: 'rgba(140,52,233,0.12)', color: '#C084FC', border: '1px solid rgba(140,52,233,0.25)' }}
+              >
+                {playing ? <Pause className="w-3 h-3" /> : <Play className="w-3 h-3" />}
+                {playing ? 'Pause tour' : 'Resume tour'}
+              </button>
+            ) : (
+              <button
+                onClick={startTour}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-[11px] font-semibold transition-colors"
+                style={{ background: 'rgba(140,52,233,0.12)', color: '#C084FC', border: '1px solid rgba(140,52,233,0.25)' }}
+              >
+                <RotateCcw className="w-3 h-3" />
+                Replay tour
+              </button>
+            )}
+          </div>
+        </header>
+
+        {/* View body */}
+        <main className="flex-1 p-4 overflow-auto" style={{ maxHeight: 620 }}>
+          {renderView(activeView)}
+        </main>
+      </div>
+
+      {/* ── Animated tour cursor ── */}
+      {showCursor && (
+        <div
+          className="absolute top-0 left-0 z-30 pointer-events-none"
+          style={{
+            transform: `translate(${cursor.x}px, ${cursor.y}px)`,
+            transition: 'transform 750ms cubic-bezier(0.4, 0, 0.2, 1)',
+          }}
+        >
+          <div className="relative -translate-y-1/2">
+            {clicking && (
+              <span className="absolute -left-1.5 -top-1.5 w-7 h-7 rounded-full animate-ping" style={{ background: 'rgba(140,52,233,0.4)' }} />
+            )}
+            <MousePointer2 className="w-5 h-5 drop-shadow-lg" style={{ color: '#fff', fill: '#8C34E9' }} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/demos/xmatrix/XMatrixDemo.tsx
+++ b/client/src/components/demos/xmatrix/XMatrixDemo.tsx
@@ -1,0 +1,336 @@
+/*
+ * XMatrixDemo — self-contained port of the real Policy Deployment X-Matrix
+ * (oplytics-policy-deployment/client/src/components/XMatrix.tsx).
+ *
+ * The product component pulls { plan, toggleCorrelation, setHighlightedIds } from
+ * PolicyContext. Here we inject hardcoded fictional sample data instead, hold the
+ * plan in local state (so correlation toggles work), and drop the cross-component
+ * highlight broadcast (we already manage hover/highlight locally). No auth, no API.
+ */
+import { useCallback, useState } from 'react';
+import { FileX2 } from 'lucide-react';
+import {
+  SQDCP_PILLARS,
+  SQDCP_PILLAR_LABELS,
+  getCategoryColor,
+} from './xmatrixTokens';
+import {
+  testaPolicyPlan,
+  type PolicyPlan,
+  type Correlation,
+  type CorrelationQuadrant,
+} from '../data/testaPolicyPlan';
+
+const cellBorder = '1px solid #1e2738';
+const cellBg = '#0e1624';
+const headerBg = '#131b2e';
+
+function CorrelationDot({ sourceId, targetId, quadrant, correlations, onToggle }: {
+  sourceId: string;
+  targetId: string;
+  quadrant: CorrelationQuadrant;
+  correlations: Correlation[];
+  onToggle: (s: string, t: string, q: CorrelationQuadrant) => void;
+}) {
+  const corr = correlations.find(c => c.sourceId === sourceId && c.targetId === targetId && c.quadrant === quadrant);
+  return (
+    <button
+      onClick={() => onToggle(sourceId, targetId, quadrant)}
+      className="w-full h-full flex items-center justify-center correlation-dot"
+      title={corr ? `${corr.strength} correlation (click to cycle)` : 'No correlation (click to add)'}
+    >
+      {corr?.strength === 'strong' && (
+        <div className="w-3.5 h-3.5 rounded-full" style={{ background: '#e2e8f0' }} />
+      )}
+      {corr?.strength === 'weak' && (
+        <div className="w-3.5 h-3.5 rounded-full bg-transparent" style={{ border: '2px solid #8890a0' }} />
+      )}
+      {!corr && (
+        <div className="w-3.5 h-3.5 rounded-full bg-transparent opacity-0 hover:opacity-30 transition-opacity" style={{ border: '1px solid #2e3a4e' }} />
+      )}
+    </button>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, { bg: string; color: string; border: string }> = {
+    'on-track': { bg: 'rgba(16,185,129,0.12)', color: '#10b981', border: 'rgba(16,185,129,0.3)' },
+    'at-risk': { bg: 'rgba(245,158,11,0.12)', color: '#f59e0b', border: 'rgba(245,158,11,0.3)' },
+    'off-track': { bg: 'rgba(239,68,68,0.12)', color: '#ef4444', border: 'rgba(239,68,68,0.3)' },
+    'not-started': { bg: 'rgba(100,116,139,0.12)', color: '#8890a0', border: 'rgba(100,116,139,0.3)' },
+    'completed': { bg: 'rgba(16,185,129,0.12)', color: '#10b981', border: 'rgba(16,185,129,0.3)' },
+  };
+  const s = styles[status] || styles['not-started'];
+  return (
+    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded" style={{ background: s.bg, color: s.color, border: `1px solid ${s.border}` }}>
+      {status.replace('-', ' ').toUpperCase()}
+    </span>
+  );
+}
+
+export interface XMatrixDemoProps {
+  /** Override the sample plan (defaults to the fictional Testa Group plan). */
+  plan?: PolicyPlan;
+  /** When true, clicking a correlation dot cycles none → weak → strong → none. */
+  interactive?: boolean;
+  /** Drive the row/column highlight externally (e.g. an auto-play tour). */
+  externalHighlightId?: string | null;
+}
+
+export default function XMatrixDemo({ plan, interactive = false, externalHighlightId = null }: XMatrixDemoProps) {
+  const [planState, setPlanState] = useState<PolicyPlan>(plan ?? testaPolicyPlan);
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+
+  const { breakthroughObjectives: bos, annualObjectives: aos, projects, kpis, correlations } = planState;
+
+  const toggleCorrelation = useCallback((sourceId: string, targetId: string, quadrant: CorrelationQuadrant) => {
+    if (!interactive) return;
+    setPlanState(prev => {
+      const idx = prev.correlations.findIndex(c => c.sourceId === sourceId && c.targetId === targetId && c.quadrant === quadrant);
+      const next = [...prev.correlations];
+      if (idx === -1) {
+        next.push({ sourceId, targetId, quadrant, strength: 'weak' });
+      } else if (next[idx].strength === 'weak') {
+        next[idx] = { ...next[idx], strength: 'strong' };
+      } else {
+        next.splice(idx, 1);
+      }
+      return { ...prev, correlations: next };
+    });
+  }, [interactive]);
+
+  const getRelatedIds = useCallback((itemId: string) => {
+    const related = new Set<string>([itemId]);
+    correlations.forEach(c => {
+      if (c.sourceId === itemId) related.add(c.targetId);
+      if (c.targetId === itemId) related.add(c.sourceId);
+    });
+    return Array.from(related);
+  }, [correlations]);
+
+  // Hover takes priority; otherwise an external driver (auto-play tour) can highlight.
+  const activeItem = hoveredItem ?? externalHighlightId;
+  const isHighlighted = (id: string) => !activeItem || getRelatedIds(activeItem).includes(id);
+  const isAnyHovered = activeItem !== null && activeItem !== undefined;
+
+  if (!planState) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <FileX2 className="w-12 h-12 mb-4" style={{ color: '#596475' }} />
+        <h2 className="text-lg font-semibold text-[#E2E8F0] mb-2">No Policy Plan</h2>
+        <p className="text-sm text-[#596475] max-w-md">No strategic policy plan exists for this enterprise yet.</p>
+      </div>
+    );
+  }
+
+  const aoCount = aos.length;
+  const kpiCount = kpis.length;
+
+  return (
+    <div className="w-full overflow-auto">
+      {/* Title Bar — Oplytics purple gradient */}
+      <div className="px-6 py-3 rounded-t-md" style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}>
+        <h2 className="text-lg font-black text-white tracking-wide">{planState.title}</h2>
+        <p className="text-sm text-white/60">Owner: {planState.owner} | Last Updated: {planState.lastUpdated} | Year: {planState.year}</p>
+      </div>
+
+      <div className="rounded-b-md overflow-auto" style={{ background: cellBg, border: cellBorder, borderTop: 'none' }}>
+        <table className="border-collapse w-full" style={{ minWidth: '1100px' }}>
+          <tbody>
+            {/* Column headers row */}
+            <tr>
+              <td colSpan={aoCount} style={{ background: headerBg, border: cellBorder }} className="p-1 text-center">
+                <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: '#596475' }}>Annual Objectives</span>
+              </td>
+              <td style={{ background: headerBg, border: cellBorder }} className="p-1 text-center">
+                <span className="text-[10px] font-semibold" style={{ color: '#596475' }}>Code</span>
+              </td>
+              <td style={{ background: headerBg, border: cellBorder }} className="p-1">
+                <span className="text-[10px] font-semibold" style={{ color: '#596475' }}>Projects</span>
+              </td>
+              <td style={{ background: headerBg, border: cellBorder }} className="p-1 text-center">
+                <span className="text-[10px] font-semibold" style={{ color: '#596475' }}>Status</span>
+              </td>
+              <td colSpan={kpiCount} style={{ background: headerBg, border: cellBorder }} className="p-1 text-center">
+                <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: '#596475' }}>KPIs</span>
+              </td>
+              <td style={{ background: headerBg, border: cellBorder }} className="p-1 text-center">
+                <span className="text-[10px] font-semibold" style={{ color: '#596475' }}>Owner</span>
+              </td>
+            </tr>
+
+            {/* Project rows */}
+            {projects.map((proj) => (
+              <tr
+                key={proj.id}
+                onMouseEnter={() => setHoveredItem(proj.id)}
+                onMouseLeave={() => setHoveredItem(null)}
+                className={`transition-opacity duration-150 ${isAnyHovered && !isHighlighted(proj.id) ? 'opacity-30' : 'opacity-100'}`}
+              >
+                {aos.map(ao => (
+                  <td key={`${ao.id}-${proj.id}`} className="w-7 h-7 p-0 xmatrix-cell" style={{ border: cellBorder, background: cellBg }}>
+                    <CorrelationDot sourceId={ao.id} targetId={proj.id} quadrant="ao-proj" correlations={correlations} onToggle={toggleCorrelation} />
+                  </td>
+                ))}
+                <td className="px-2 py-1 text-center font-mono text-xs font-medium whitespace-nowrap" style={{ border: cellBorder, background: cellBg, color: '#8890a0' }}>
+                  {proj.code}
+                </td>
+                <td className="px-0 py-0.5 min-w-[240px]" style={{ border: cellBorder, background: cellBg }}>
+                  <div className="flex items-center gap-0">
+                    <div
+                      className="w-full px-2 py-1.5 rounded-sm text-xs font-medium text-white truncate"
+                      style={{ backgroundColor: getCategoryColor(proj.category), maxWidth: '100%' }}
+                      title={proj.name}
+                    >
+                      {proj.name}
+                      <div className="text-[9px] opacity-80 font-normal">{proj.startDate} → {proj.endDate}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-1 py-1 text-center" style={{ border: cellBorder, background: cellBg }}>
+                  <StatusBadge status={proj.status} />
+                </td>
+                {kpis.map(kpi => (
+                  <td key={`${proj.id}-${kpi.id}`} className="w-7 h-7 p-0 xmatrix-cell" style={{ border: cellBorder, background: cellBg }}>
+                    <CorrelationDot sourceId={proj.id} targetId={kpi.id} quadrant="proj-kpi" correlations={correlations} onToggle={toggleCorrelation} />
+                  </td>
+                ))}
+                <td className="px-2 py-1 text-xs whitespace-nowrap" style={{ border: cellBorder, background: cellBg, color: '#8890a0' }}>
+                  {proj.owner}
+                </td>
+              </tr>
+            ))}
+
+            {/* CENTER SECTION: X graphic */}
+            <tr>
+              <td colSpan={aoCount} className="p-0 h-0" style={{ border: cellBorder, background: cellBg }}>
+                <div className="flex h-full">
+                  {aos.map((ao) => (
+                    <div
+                      key={ao.id}
+                      className={`flex-1 flex items-end justify-center pb-1 transition-opacity duration-150 ${isAnyHovered && !isHighlighted(ao.id) ? 'opacity-30' : 'opacity-100'}`}
+                      onMouseEnter={() => setHoveredItem(ao.id)}
+                      onMouseLeave={() => setHoveredItem(null)}
+                    >
+                      <div className="text-[10px] font-medium leading-tight text-center" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', maxHeight: '120px', overflow: 'hidden', color: '#8890a0' }}>
+                        {ao.description}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </td>
+
+              <td colSpan={3} className="relative" style={{ height: '200px', border: cellBorder, background: cellBg }}>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <svg viewBox="0 0 200 200" className="w-full h-full max-w-[200px] max-h-[200px] opacity-15">
+                    <line x1="0" y1="0" x2="200" y2="200" stroke="#8C34E9" strokeWidth="2" />
+                    <line x1="200" y1="0" x2="0" y2="200" stroke="#8C34E9" strokeWidth="2" />
+                  </svg>
+                  <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+                    <span className="text-xs font-bold uppercase tracking-widest mb-auto mt-3" style={{ color: '#8C34E9' }}>Projects</span>
+                    <div className="flex items-center justify-between w-full px-3">
+                      <span className="text-[9px] font-bold uppercase tracking-widest" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', color: '#1DB8CE' }}>Annual Objectives</span>
+                      <span className="text-4xl font-black select-none" style={{ color: 'rgba(140,52,233,0.2)' }}>X</span>
+                      <span className="text-xs font-bold uppercase tracking-widest" style={{ writingMode: 'vertical-rl', color: '#1DB8CE' }}>KPIs</span>
+                    </div>
+                    <span className="text-[9px] font-bold uppercase tracking-widest mt-auto mb-3" style={{ color: '#f97316' }}>Breakthrough Objectives (BO)</span>
+                  </div>
+                </div>
+              </td>
+
+              <td colSpan={kpiCount} className="p-0" style={{ border: cellBorder, background: cellBg }}>
+                <div className="flex h-full">
+                  {kpis.map((kpi) => (
+                    <div
+                      key={kpi.id}
+                      className={`flex-1 flex items-start justify-center pt-1 transition-opacity duration-150 ${isAnyHovered && !isHighlighted(kpi.id) ? 'opacity-30' : 'opacity-100'}`}
+                      onMouseEnter={() => setHoveredItem(kpi.id)}
+                      onMouseLeave={() => setHoveredItem(null)}
+                    >
+                      <div className="text-[10px] font-medium leading-tight text-center" style={{ writingMode: 'vertical-rl', maxHeight: '120px', overflow: 'hidden', color: '#8890a0' }}>
+                        {kpi.name}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </td>
+
+              <td className="p-1 text-center" style={{ border: cellBorder, background: headerBg }}>
+                <span className="text-[10px] font-semibold uppercase" style={{ color: '#596475' }}>Projects Leader</span>
+              </td>
+            </tr>
+
+            {/* AO code row */}
+            <tr>
+              {aos.map(ao => (
+                <td key={ao.id} className="p-0.5 text-center w-7" style={{ background: headerBg, border: cellBorder }}>
+                  <span className="font-mono text-[10px] font-bold" style={{ color: '#596475' }}>{ao.code}</span>
+                </td>
+              ))}
+              <td colSpan={3} style={{ background: headerBg, border: cellBorder }} />
+              {kpis.map(kpi => (
+                <td key={kpi.id} className="p-0.5 text-center w-7" style={{ background: headerBg, border: cellBorder }}>
+                  <span className="font-mono text-[10px] font-bold" style={{ color: '#596475' }}>{kpi.code}</span>
+                </td>
+              ))}
+              <td style={{ background: headerBg, border: cellBorder }} />
+            </tr>
+
+            {/* BOTTOM SECTION: Breakthrough Objectives */}
+            {bos.map((bo) => (
+              <tr
+                key={bo.id}
+                onMouseEnter={() => setHoveredItem(bo.id)}
+                onMouseLeave={() => setHoveredItem(null)}
+                className={`transition-opacity duration-150 ${isAnyHovered && !isHighlighted(bo.id) ? 'opacity-30' : 'opacity-100'}`}
+              >
+                {aos.map(ao => (
+                  <td key={`${bo.id}-${ao.id}`} className="w-7 h-7 p-0 xmatrix-cell" style={{ border: cellBorder, background: cellBg }}>
+                    <CorrelationDot sourceId={bo.id} targetId={ao.id} quadrant="bo-ao" correlations={correlations} onToggle={toggleCorrelation} />
+                  </td>
+                ))}
+                <td className="px-2 py-1 text-center font-mono text-xs font-medium whitespace-nowrap" style={{ border: cellBorder, background: cellBg, color: '#8890a0' }}>
+                  {bo.code}
+                </td>
+                <td className="px-2 py-1.5 text-xs min-w-[240px]" style={{ border: cellBorder, background: cellBg, color: '#c0c6d0' }}>
+                  {bo.description}
+                </td>
+                <td className="px-1 py-1 text-center" style={{ border: cellBorder, background: cellBg }}>
+                  <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded uppercase" style={{ background: 'rgba(140,52,233,0.12)', color: '#8C34E9' }}>
+                    {bo.category}
+                  </span>
+                </td>
+                {kpis.map(kpi => (
+                  <td key={`${kpi.id}-${bo.id}`} className="w-7 h-7 p-0 xmatrix-cell" style={{ border: cellBorder, background: cellBg }}>
+                    <CorrelationDot sourceId={kpi.id} targetId={bo.id} quadrant="kpi-bo" correlations={correlations} onToggle={toggleCorrelation} />
+                  </td>
+                ))}
+                <td style={{ border: cellBorder, background: cellBg }} />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-6 mt-3 px-2 pb-1 flex-wrap">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-full" style={{ background: '#e2e8f0' }} />
+          <span className="text-xs" style={{ color: '#596475' }}>Strong correlation</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-full bg-transparent" style={{ border: '2px solid #8890a0' }} />
+          <span className="text-xs" style={{ color: '#596475' }}>Weak correlation</span>
+        </div>
+        <div className="flex items-center gap-4 ml-auto">
+          {SQDCP_PILLARS.map(pillar => (
+            <div key={pillar} className="flex items-center gap-1.5">
+              <div className="w-3 h-3 rounded-sm" style={{ backgroundColor: getCategoryColor(pillar) }} />
+              <span className="text-xs" style={{ color: '#596475' }}>{SQDCP_PILLAR_LABELS[pillar]}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/demos/xmatrix/useAutoHighlight.ts
+++ b/client/src/components/demos/xmatrix/useAutoHighlight.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Cycles through a list of ids on an interval — used to drive the X-Matrix demo's
+ * highlight without user interaction (the "guided auto-play tour" on the home cards).
+ * Returns the currently-active id, or null when the list is empty.
+ */
+export function useAutoHighlight(ids: string[], intervalMs = 2000): string | null {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (ids.length === 0) return;
+    const timer = setInterval(() => {
+      setIndex(prev => (prev + 1) % ids.length);
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [ids.length, intervalMs]);
+
+  return ids[index % Math.max(ids.length, 1)] ?? null;
+}
+
+export default useAutoHighlight;

--- a/client/src/components/demos/xmatrix/xmatrixTokens.ts
+++ b/client/src/components/demos/xmatrix/xmatrixTokens.ts
@@ -1,0 +1,40 @@
+/**
+ * SQDCP pillar tokens — inlined from @pablo2410/core-server + oplytics-policy-deployment's
+ * lib/store.ts so the marketing demo has zero dependency on the product packages.
+ * Keep these values in sync with SQDCP_PILLAR_COLORS in @pablo2410/core-server.
+ */
+export const SQDCP_PILLARS = ['safety', 'quality', 'delivery', 'cost', 'people'] as const;
+
+export const SQDCP_PILLAR_COLORS: Record<string, string> = {
+  safety: '#ef4444',
+  quality: '#3b82f6',
+  delivery: '#f59e0b',
+  cost: '#10b981',
+  people: '#a855f7',
+};
+
+export const SQDCP_PILLAR_LABELS: Record<string, string> = {
+  safety: 'Safety',
+  quality: 'Quality',
+  delivery: 'Delivery',
+  cost: 'Cost',
+  people: 'People',
+};
+
+/** Mirrors getCategoryColor() in oplytics-policy-deployment/client/src/lib/store.ts */
+export function getCategoryColor(category: string): string {
+  return SQDCP_PILLAR_COLORS[category] ?? '#64748b';
+}
+
+export const STATUS_COLORS: Record<string, string> = {
+  'on-track': '#10b981',
+  'at-risk': '#f59e0b',
+  'off-track': '#ef4444',
+  'not-started': '#596475',
+  'completed': '#10b981',
+};
+
+/** Mirrors getStatusColor() in oplytics-policy-deployment/client/src/lib/store.ts */
+export function getStatusColor(status: string): string {
+  return STATUS_COLORS[status] ?? '#596475';
+}

--- a/client/src/components/shared/AnimatedServiceCard.tsx
+++ b/client/src/components/shared/AnimatedServiceCard.tsx
@@ -3,9 +3,12 @@
  * Each card shows a mini animated graphic — X-Matrix for Policy Deployment,
  * OEE gauge for OEE Manager, SQDCP board for SQDCP Dashboard, etc.
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Link } from 'wouter';
 import { ArrowRight, Target, LayoutGrid, Gauge, Plug, ClipboardCheck, Shield, CheckCircle, Award } from 'lucide-react';
+import XMatrixDemo from '@/components/demos/xmatrix/XMatrixDemo';
+import { useAutoHighlight } from '@/components/demos/xmatrix/useAutoHighlight';
+import { testaPolicyPlan } from '@/components/demos/data/testaPolicyPlan';
 
 const iconMap: Record<string, React.ComponentType<{ className?: string; style?: React.CSSProperties }>> = {
   Target, LayoutGrid, Gauge, Plug, ClipboardCheck, Shield, CheckCircle, Award,
@@ -14,39 +17,24 @@ const iconMap: Record<string, React.ComponentType<{ className?: string; style?: 
 /* ─── Mini Animated Graphics ─── */
 
 function PolicyDeploymentGraphic() {
-  const [phase, setPhase] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setPhase(p => (p + 1) % 4), 2000);
-    return () => clearInterval(id);
-  }, []);
-  const cells = [
-    ['Strategy', 'KPIs', 'Targets', 'Actions'],
-    ['Growth', '↑12%', '£2.4M', '●●●○'],
-    ['Quality', '98.2%', '99%', '●●○○'],
-    ['Safety', '0 LTI', '0', '●●●●'],
-  ];
+  // Auto-play tour: rotate the highlight through annual objectives then projects so
+  // the mini X-Matrix continuously traces its own correlations, no interaction needed.
+  const tourIds = useMemo(
+    () => [
+      ...testaPolicyPlan.annualObjectives.map(a => a.id),
+      ...testaPolicyPlan.projects.map(p => p.id),
+    ],
+    []
+  );
+  const highlightId = useAutoHighlight(tourIds, 1800);
+
   return (
-    <div className="w-full h-full flex items-center justify-center p-3">
-      <div className="w-full">
-        <div className="text-[8px] font-bold mb-1.5 text-center" style={{ color: '#8C34E9' }}>X-Matrix</div>
-        <div className="grid grid-cols-4 gap-[2px]">
-          {cells.map((row, ri) =>
-            row.map((cell, ci) => (
-              <div
-                key={`${ri}-${ci}`}
-                className="text-[6px] text-center py-1 px-0.5 rounded-sm transition-all duration-500"
-                style={{
-                  background: ri === 0 ? '#8C34E920' : phase === ri - 1 ? '#8C34E930' : '#0d122080',
-                  color: ri === 0 ? '#8C34E9' : phase === ri - 1 ? '#fff' : '#596475',
-                  fontWeight: ri === 0 ? 700 : 400,
-                  fontFamily: 'Montserrat',
-                }}
-              >
-                {cell}
-              </div>
-            ))
-          )}
-        </div>
+    <div className="w-full h-full overflow-hidden relative" style={{ background: '#0a0e1a' }}>
+      <div
+        className="absolute top-0 left-0 origin-top-left pointer-events-none"
+        style={{ transform: 'scale(0.26)', width: '1180px' }}
+      >
+        <XMatrixDemo externalHighlightId={highlightId} />
       </div>
     </div>
   );

--- a/client/src/pages/SolutionPage.tsx
+++ b/client/src/pages/SolutionPage.tsx
@@ -31,7 +31,7 @@ import IoTShowcaseSection from '@/components/shared/IoTShowcaseSection';
 import ConnectRolesProtocolsSection from '@/components/shared/ConnectRolesProtocolsSection';
 import TierMeetingSection from '@/components/shared/TierMeetingSection';
 import { getServiceBySlug, getCrossSellServices, getClaimTierLabel } from '@/config/services';
-import { demoComponents } from '@/components/demos';
+import { demoComponents, interactiveDemos } from '@/components/demos';
 import { Link } from 'wouter';
 import {
   Gauge, LayoutGrid, ClipboardCheck, Shield, Target,
@@ -217,14 +217,45 @@ export default function SolutionPage() {
               </div>
             );
 
+            const demoFallback = (
+              <div className="aspect-video flex items-center justify-center">
+                <div className="animate-pulse text-[#596475] text-sm">Loading demo...</div>
+              </div>
+            );
+
+            /* Live, user-driven demos: no click-swallowing overlay — a non-blocking
+               caption + CTA sits below the demo instead. */
+            if (DemoComponent && interactiveDemos.has(service.slug)) {
+              return (
+                <div className="rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden">
+                  <Suspense fallback={demoFallback}>
+                    <DemoComponent />
+                  </Suspense>
+                  <div className="flex items-center justify-between gap-3 px-4 py-3 border-t border-[#1E2738] flex-wrap">
+                    <span className="text-xs text-[#596475]">
+                      Guided tour with sample data — it settles on the live X-Matrix: hover a row to trace its correlations, click the dots to edit links.
+                    </span>
+                    <Link
+                      href="/contact"
+                      data-umami-event="cta_click"
+                      data-umami-event-button="request_live_demo"
+                      data-umami-event-location="solution_demo"
+                      data-umami-event-service={service.slug}
+                      className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-white font-semibold text-xs transition-all hover:scale-105 flex-shrink-0"
+                      style={{ background: 'linear-gradient(135deg, #8C34E9 0%, #5B1FA6 100%)' }}
+                    >
+                      Open the full app
+                      <ArrowRight className="w-3.5 h-3.5" />
+                    </Link>
+                  </div>
+                </div>
+              );
+            }
+
             if (DemoComponent) {
               return (
                 <div className="relative rounded-lg border border-[#1E2738] bg-[#0D1220] overflow-hidden group">
-                  <Suspense fallback={
-                    <div className="aspect-video flex items-center justify-center">
-                      <div className="animate-pulse text-[#596475] text-sm">Loading demo...</div>
-                    </div>
-                  }>
+                  <Suspense fallback={demoFallback}>
                     <DemoComponent />
                   </Suspense>
                   {overlay}


### PR DESCRIPTION
## What
Replaces the **fixed Policy Deployment screenshot** on the marketing site with a working, interactive demo of the actual service, plus an auto-playing product tour. First step of rolling live demos across the solutions section.

## The tour
Opens on the **Dashboard**, an animated cursor "clicks" through the sidebar — **X-Matrix → Catchball (Goal Cascade) → Bowling Chart** — then settles on the **live, clickable X-Matrix** (hover a row to trace correlations; click dots to cycle none→weak→strong). The sidebar stays interactive throughout; **Pause/Resume** + **Replay tour** controls in the header.

## How (self-contained — "Option A")
- Real product views (**Dashboard, Bowling Chart, Catchball, X-Matrix**) ported into the marketing repo, fed fictional **Testa Group** sample data — no auth, no backend, **no real customer names**.
- **No browser-frame wrapper** — framed in the app's own sidebar/header chrome.
- Home solution card now shows a compact auto-highlighting X-Matrix.
- Reusable rails for the SQDCP / Action Manager / Connect rollout (`interactiveDemos` flag, `demos/data` + `demos/<solution>` convention, `useAutoHighlight` hook).

## Verification
- `tsc` clean for all changed files (pre-existing `Map.tsx`/`ui/*` errors untouched).
- `vite build` green; Policy Deployment demo lazy-chunked.
- Real-name scan over new demo code is clean.

## Follow-ups (not in this PR)
- Existing **SQDCP** demo still shows a real screenshot + "Vita" alt text — port next (same recipe).
- "Cascade" maps to the **Catchball** view; swap to **Deployments** if preferred (one line).
- **Action Plans** / **Deployments** sidebar items are light placeholders (not yet ported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)