### PR TITLE
chore(deps): bump shared-ui → 0.9.2 + core-server → 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
-    "@pablo2410/core-server": "^0.3.0",
+    "@pablo2410/core-server": "^0.5.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -41,7 +41,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "axios": "^1.12.0",
-    "@pablo2410/shared-ui": "^0.9.0",
+    "@pablo2410/shared-ui": "^0.9.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
       '@pablo2410/core-server':
-        specifier: ^0.3.0
-        version: 0.3.0(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
+        specifier: ^0.5.2
+        version: 0.5.2(@pablo2410/shared-ui@0.9.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
       '@pablo2410/shared-ui':
-        specifier: ^0.9.0
-        version: 0.9.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
+        specifier: ^0.9.2
+        version: 0.9.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -865,15 +865,18 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@pablo2410/core-server@0.3.0':
-    resolution: {integrity: sha512-jhbh6jpgiVmtJnMhml6qjuY2toZICmux9hbmpRENtKnpdK2loItJ3QBQpmi1zNtw4KWbGzn7P1JvGVxR63grHQ==}
+  '@pablo2410/core-server@0.5.2':
+    resolution: {integrity: sha512-HMJ9hy9jqAa2Utwv8wiESxLQN4ZZHrU87+s8URQQDMb9BsDXQVTY2opufV4ifprNQIq4N6xVHC0jvtb9tgKCRw==}
     peerDependencies:
+      '@pablo2410/shared-ui': '>=0.7.0'
       '@trpc/server': '>=11.0.0'
       axios: '>=1.0.0'
       cookie: '>=0.6.0'
       express: '>=4.0.0'
       jose: '>=5.0.0'
     peerDependenciesMeta:
+      '@pablo2410/shared-ui':
+        optional: true
       axios:
         optional: true
       cookie:
@@ -883,8 +886,8 @@ packages:
       jose:
         optional: true
 
-  '@pablo2410/shared-ui@0.9.0':
-    resolution: {integrity: sha512-wa0OEWcL0UuCKj6rjsRzr0SPBMSHkoHqIx4XVFVbnSHt15swWDdjPpjhedX/QGAkaCnUmxNW90yXJx8SiK14iQ==}
+  '@pablo2410/shared-ui@0.9.2':
+    resolution: {integrity: sha512-YmSms8xtOxjKxnXNBRG4jr/tmEiMhhBGoCM74knTK/seDbmCfZFIR35e3iFQdulj4QAhGaCSFbVXkaHydp5RKg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -4307,15 +4310,16 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@pablo2410/core-server@0.3.0(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
+  '@pablo2410/core-server@0.5.2(@pablo2410/shared-ui@0.9.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
     dependencies:
       '@trpc/server': 11.17.0(typescript@5.6.3)
     optionalDependencies:
+      '@pablo2410/shared-ui': 0.9.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
       axios: 1.13.6
       cookie: 0.7.2
       express: 4.22.1
 
-  '@pablo2410/shared-ui@0.9.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)':
+  '@pablo2410/shared-ui@0.9.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

Aligns marketing-site to the latest published internal packages:
- `@pablo2410/shared-ui` → **0.9.2** (^0.9.0 → ^0.9.2)
- `@pablo2410/core-server` → **0.5.2** (^0.3.0 → ^0.5.2 — a 2-minor jump, used in `server/`)

## Verification
- `tsc --noEmit` clean. (The only tsc errors are from pre-existing **untracked** `* 2.tsx` duplicate scratch files unrelated to this change — none are git-tracked, none reference the bumped packages.)
- Full `vite build` + `esbuild` server bundle succeed.

Dependency + lockfile only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)