### PR TITLE
fix: repoint contact form and login redirect to oplyticsdigital.net

### DIFF
--- a/client/src/components/shared/ContactForm.tsx
+++ b/client/src/components/shared/ContactForm.tsx
@@ -46,7 +46,7 @@ export default function ContactForm({ context, compact = false }: ContactFormPro
       (window as any).umami.track('contact_form_submit', { context: context || 'marketing-site' });
     }
     try {
-      const res = await fetch('https://portal.oplytics.digital/api/leads', {
+      const res = await fetch('https://portal.oplyticsdigital.net/api/leads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -7,7 +7,7 @@ import MarketingLayout from '@/components/shared/MarketingLayout';
 import { Link } from 'wouter';
 import { ExternalLink, Loader2 } from 'lucide-react';
 
-const PLATFORM_LOGIN_URL = 'https://portal.oplytics.digital/login';
+const PLATFORM_LOGIN_URL = 'https://portal.oplyticsdigital.net/login';
 
 export default function Login() {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Marketing site's contact form POSTs leads to `portal.oplytics.digital/api/leads` — repointed to `portal.oplyticsdigital.net`.
- `Login.tsx`'s redirect target likewise repointed to the new domain.
- Part of the oplytics.digital → marketing-only cutover: all auth/API traffic now lives on oplyticsdigital.net.

No change needed to portal's `leadsApi.ts` CORS allowlist — it's keyed to the marketing site's own origin (`oplytics.digital`/`www.oplytics.digital`), which is unaffected by this change.

## Test plan
- [ ] Submit the contact form on a preview/staging build and confirm the lead lands in portal (no CORS/network error in console)
- [ ] Visit `/login` and confirm redirect lands on `portal.oplyticsdigital.net/login`