### PR TITLE
fix(ai): wire GEMINI_API_KEY/GEMINI_API_URL for Opi's support engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
-    "@pablo2410/core-server": "^0.5.2",
+    "@pablo2410/core-server": "^0.6.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
       '@pablo2410/core-server':
-        specifier: ^0.5.2
-        version: 0.5.2(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
+        specifier: ^0.6.0
+        version: 0.6.0(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
       '@pablo2410/shared-ui':
         specifier: ^0.12.2
         version: 0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
@@ -865,8 +865,8 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@pablo2410/core-server@0.5.2':
-    resolution: {integrity: sha512-HMJ9hy9jqAa2Utwv8wiESxLQN4ZZHrU87+s8URQQDMb9BsDXQVTY2opufV4ifprNQIq4N6xVHC0jvtb9tgKCRw==}
+  '@pablo2410/core-server@0.6.0':
+    resolution: {integrity: sha512-DS6T9ZR+IZwXblhjhXMT1HVJ8E34RTOQi6GBIuo8iF7BqaOT+LrrptshLAmVJBriofPBYb0Vd+kYK3wugIy/mg==}
     peerDependencies:
       '@pablo2410/shared-ui': '>=0.7.0'
       '@trpc/server': '>=11.0.0'
@@ -4310,7 +4310,7 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@pablo2410/core-server@0.5.2(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
+  '@pablo2410/core-server@0.6.0(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
     dependencies:
       '@trpc/server': 11.17.0(typescript@5.6.3)
     optionalDependencies:

--- a/server/env.ts
+++ b/server/env.ts
@@ -10,6 +10,10 @@ const envSchema = z.object({
   // (not at construction), so Opi degrades to a friendly 500 while the site
   // stays up.
   FORGE_API_KEY: z.string().min(1).optional(),
+  // Opi's LLM backend — Gemini directly (see createSupportEngine below), not
+  // Forge. Same optional-at-boot rationale as FORGE_API_KEY above.
+  GEMINI_API_URL: z.string().url().optional(),
+  GEMINI_API_KEY: z.string().min(1).optional(),
   // AI usage ledger (Business Hub). Both optional — metering is skipped (fail-open)
   // until they're set, so the site runs fine without them.
   AI_USAGE_LEDGER_URL: z.string().url().optional(),

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,7 +13,12 @@ const __dirname = path.dirname(__filename);
 // knowledge base live in @pablo2410/core-server; metering + budget guard are
 // injected so every call is recorded and cost-controlled via the ledger.
 const supportEngine = createSupportEngine(
-  { forgeApiUrl: ENV.FORGE_API_URL ?? "", forgeApiKey: ENV.FORGE_API_KEY ?? "" },
+  {
+    forgeApiUrl: ENV.FORGE_API_URL ?? "",
+    forgeApiKey: ENV.FORGE_API_KEY ?? "",
+    geminiApiUrl: ENV.GEMINI_API_URL ?? "",
+    geminiApiKey: ENV.GEMINI_API_KEY ?? "",
+  },
   {
     knowledgeLimit: 6,
     metering: {


### PR DESCRIPTION
## Summary
- Bumps `@pablo2410/core-server` to `^0.6.0` (Oplytics-Digital/oplytics-core-server#16), which switches `createLLMClient` from Manus's Forge gateway to calling Gemini directly.
- Adds `GEMINI_API_URL`/`GEMINI_API_KEY` to `server/env.ts` (optional, same fail-open rationale as the existing `FORGE_API_*` fields — a missing key must not crash boot) and passes them into `createSupportEngine` in `server/index.ts` alongside the now-inert `forgeApiUrl`/`forgeApiKey`.
- `server/llm.ts` (a local vendored LLM fork) is confirmed dead code — nothing in this repo imports it, `createSupportEngine` comes straight from `@pablo2410/core-server` — left untouched.

## Test plan
- [x] `pnpm check` (tsc) — clean
- [x] `pnpm build` — succeeds
- [ ] After merge: add `GEMINI_API_KEY`/`GEMINI_API_URL` wherever this server actually runs in production, redeploy, verify Opi responds for real on the marketing site

🤖 Generated with [Claude Code](https://claude.com/claude-code)