### PR TITLE
feat: deploy the server to the VPS so Opi chat actually runs

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -1,0 +1,55 @@
+name: Build and deploy (VPS)
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-marketing-site-vps
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        # Docker tags must be lowercase; github.repository is "Oplytics-Digital/..."
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:latest
+            ${{ steps.meta.outputs.image }}:${{ github.sha }}
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to VPS over SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            cd /opt/oplytics
+            docker compose pull marketing-site
+            docker compose up -d marketing-site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+FROM node:20-slim AS base
+RUN corepack enable
+WORKDIR /app
+
+# ---- install all deps, including dev deps needed to build ----
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
+RUN pnpm install --frozen-lockfile
+
+# ---- build client (vite) + server bundle (esbuild) ----
+FROM deps AS build
+COPY . .
+RUN pnpm run build
+
+# ---- production-only deps ----
+FROM base AS prod-deps
+COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
+RUN pnpm install --frozen-lockfile --prod
+
+# ---- final runtime image ----
+FROM base AS runner
+ENV NODE_ENV=production
+ENV PORT=3000
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
-    "@pablo2410/core-server": "^0.6.0",
+    "@pablo2410/core-server": "^0.6.1",
+    "@pablo2410/shared-ui": "^0.12.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -41,7 +42,6 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "axios": "^1.12.0",
-    "@pablo2410/shared-ui": "^0.12.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
       '@pablo2410/core-server':
-        specifier: ^0.6.0
-        version: 0.6.0(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
+        specifier: ^0.6.1
+        version: 0.6.1(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
       '@pablo2410/shared-ui':
         specifier: ^0.12.2
         version: 0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
@@ -865,8 +865,8 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@pablo2410/core-server@0.6.0':
-    resolution: {integrity: sha512-DS6T9ZR+IZwXblhjhXMT1HVJ8E34RTOQi6GBIuo8iF7BqaOT+LrrptshLAmVJBriofPBYb0Vd+kYK3wugIy/mg==}
+  '@pablo2410/core-server@0.6.1':
+    resolution: {integrity: sha512-DBDPGgbVMNng/oBxOMdK04VZJvqhYOxtiILr/zOA++ozOeWky4v7J7fzW3++Q9ZcETdlRf9Kpz6IdE9FXJoHkw==}
     peerDependencies:
       '@pablo2410/shared-ui': '>=0.7.0'
       '@trpc/server': '>=11.0.0'
@@ -4310,7 +4310,7 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@pablo2410/core-server@0.6.0(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
+  '@pablo2410/core-server@0.6.1(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
     dependencies:
       '@trpc/server': 11.17.0(typescript@5.6.3)
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Opi chat has been unreachable in production for a reason unrelated to the Forge→Gemini fix (#96): the Cloudflare Pages deploy only ships the static `dist/public` bundle, never runs `server/index.ts` (the actual `/api/ai/chat` route). Confirmed live: `POST oplytics.digital/api/ai/chat` → 405 from Cloudflare's static handler.
- Adds a `Dockerfile` (same multi-stage pattern as `oplytics-portal`) and `.github/workflows/deploy-vps.yml` (GHCR build/push + SSH deploy, same pattern as every other app) so this repo can also run as a real container on the shared VPS.
- Bumps `@pablo2410/core-server` to `^0.6.1` (gemini-3.5-flash fix, matches portal#78).
- Companion infra PR: `oplytics-policy-deployment#113` (adds the service to the VPS's `docker-compose.yml`/`Caddyfile`, at a verification subdomain — NOT touching `oplytics.digital` DNS yet).
- Cloudflare Pages deploy (`deploy.yml`) is left untouched for now — the static site keeps serving from there until the VPS path is verified and DNS cutover is separately planned.

## Test plan
- [x] `pnpm check` — clean
- [x] `pnpm build` — succeeds
- [x] Locally simulated the Dockerfile's runtime: fresh `node_modules` installed with `--prod` only (including the `patches/wouter@3.7.1.patch` the multi-stage build needs), ran the real `dist/index.js` against it — static homepage served 200, `/api/ai/chat` reached Gemini successfully (was on core-server 0.6.0 at the time of that local test, hence the 2.5-flash 404; 0.6.1 in this PR fixes that, same as portal#78)
- [ ] After both PRs merge: verify `https://marketing.oplyticsdigital.net` live, then plan the `oplytics.digital` DNS cutover separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)