### PR TITLE
chore: bump @pablo2410/shared-ui to ^0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@pablo2410/core-server": "^0.6.1",
-    "@pablo2410/shared-ui": "^0.12.2",
+    "@pablo2410/shared-ui": "^0.13.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,10 +21,10 @@ importers:
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
       '@pablo2410/core-server':
         specifier: ^0.6.1
-        version: 0.6.1(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
+        version: 0.6.1(@pablo2410/shared-ui@0.13.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)
       '@pablo2410/shared-ui':
-        specifier: ^0.12.2
-        version: 0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
+        specifier: ^0.13.0
+        version: 0.13.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -886,8 +886,8 @@ packages:
       jose:
         optional: true
 
-  '@pablo2410/shared-ui@0.12.2':
-    resolution: {integrity: sha512-TS8BlqM/RTCV9NY9rM4Q+UBjWodHF3J/KgOWeM3RwJiaKXXj+ZXaRJjEid/qc/YErV6PGT+heMosrpZ3Py953w==}
+  '@pablo2410/shared-ui@0.13.0':
+    resolution: {integrity: sha512-TDIy5L/8Zh5WosVM1bgTR2Bj9sl+rItgmChhOY6Ra2d7SJB0zGCCxuum8ColYLerHqGPmR3ZPp+/ryseinEleg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -4310,16 +4310,16 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@pablo2410/core-server@0.6.1(@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
+  '@pablo2410/core-server@0.6.1(@pablo2410/shared-ui@0.13.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@trpc/server@11.17.0(typescript@5.6.3))(axios@1.13.6)(cookie@0.7.2)(express@4.22.1)':
     dependencies:
       '@trpc/server': 11.17.0(typescript@5.6.3)
     optionalDependencies:
-      '@pablo2410/shared-ui': 0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
+      '@pablo2410/shared-ui': 0.13.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
       axios: 1.13.6
       cookie: 0.7.2
       express: 4.22.1
 
-  '@pablo2410/shared-ui@0.12.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)':
+  '@pablo2410/shared-ui@0.13.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary
- Bumps `@pablo2410/shared-ui` from `^0.12.2` to `^0.13.0` (lockfile resolved version 0.12.2 -> 0.13.0), per the Software Version dashboard flag.
- `@pablo2410/core-server` was also flagged for review but is already at latest (`^0.6.1` = latest published) — left untouched. core-server's peer requirement (`@pablo2410/shared-ui >= 0.7.0`, optional peer) is satisfied by 0.13.0.

## Verification
- [x] `pnpm install` — lockfile updated, resolved version reaches 0.13.0
- [x] `pnpm run check` (`tsc --noEmit`) — passes clean, no errors
- [x] `pnpm run build` (`vite build` + esbuild server bundle) — passes clean, both client and server (`dist/index.js`) build successfully
- [ ] Lint — no lint script/config exists in this repo (nothing to run)
- [ ] Tests — no test files or `test` script exist in this repo (`vitest` is a devDependency but unwired)

## Call-site changes
None needed. The only direct usage of `@pablo2410/shared-ui` in this repo is `client/src/config/services.ts`, importing `SERVICE_CATALOG`, `ServiceDefinition`, `ServiceStatus`, `ServiceCategory` from `@pablo2410/shared-ui/services`. That subpath export and its shape are unchanged in 0.13.0 — typecheck and build both confirm compatibility with no code edits.

## Regression risk re: Opi VPS server
This repo recently had the Express server (Opi AI chat) deployed to the VPS. shared-ui is not imported anywhere in `server/` — only `core-server` is (`server/index.ts`, `server/aiUsageClient.ts`), and core-server's version is unchanged here. shared-ui is merely an *optional* peer dependency of core-server (used for shared type definitions, not a runtime import in the Express server path). The esbuild server bundle (`dist/index.js`) built successfully in this PR. Given the bump is client-side-only in terms of actual usage, risk to the Opi server is low — flagging for visibility rather than asserting zero risk, since I did not deploy/smoke-test the server itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)