### PR TITLE
Fix cropped screenshots + bring real screens to homepage cards

### DIFF
--- a/client/src/components/shared/AnimatedServiceCard.tsx
+++ b/client/src/components/shared/AnimatedServiceCard.tsx
@@ -9,6 +9,8 @@ import { ArrowRight, Target, LayoutGrid, Gauge, Plug, ClipboardCheck, Shield, Ch
 import XMatrixDemo from '@/components/demos/xmatrix/XMatrixDemo';
 import { useAutoHighlight } from '@/components/demos/xmatrix/useAutoHighlight';
 import { testaPolicyPlan } from '@/components/demos/data/testaPolicyPlan';
+import CardScreenshotCarousel from './CardScreenshotCarousel';
+import type { DemoScreenshot } from '@/config/services';
 
 const iconMap: Record<string, React.ComponentType<{ className?: string; style?: React.CSSProperties }>> = {
   Target, LayoutGrid, Gauge, Plug, ClipboardCheck, Shield, CheckCircle, Award,
@@ -230,11 +232,14 @@ interface AnimatedServiceCardProps {
   route: string;
   status: 'live' | 'in-development' | 'coming-soon';
   iconName?: string;
+  /** Real product screenshots — takes priority over the hardcoded mini-graphic when present */
+  demoScreenshots?: DemoScreenshot[];
 }
 
-export default function AnimatedServiceCard({ slug, name, tagline, color, route, status, iconName }: AnimatedServiceCardProps) {
+export default function AnimatedServiceCard({ slug, name, tagline, color, route, status, iconName, demoScreenshots }: AnimatedServiceCardProps) {
   const Icon = (iconName && iconMap[iconName]) || Target;
   const Graphic = graphicMap[slug];
+  const hasScreenshots = demoScreenshots && demoScreenshots.length > 0;
 
   return (
     <Link href={route}>
@@ -244,11 +249,17 @@ export default function AnimatedServiceCard({ slug, name, tagline, color, route,
         onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.borderColor = color + '40'; }}
         onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.borderColor = '#1e2738'; }}
       >
-        {/* Graphic area — taller so screenshots are legible */}
-        <div className="h-40 relative overflow-hidden" style={{ background: '#0a0e1a' }}>
-          {Graphic ? <Graphic /> : (
-            <div className="w-full h-full flex items-center justify-center">
-              <Icon className="w-8 h-8" style={{ color, opacity: 0.3 }} />
+        {/* Graphic area — real screenshots take priority; native ratio preserved, no crop */}
+        <div className="relative overflow-hidden" style={{ background: '#0a0e1a' }}>
+          {hasScreenshots ? (
+            <CardScreenshotCarousel slides={demoScreenshots} serviceName={name} />
+          ) : (
+            <div className="h-40">
+              {Graphic ? <Graphic /> : (
+                <div className="w-full h-full flex items-center justify-center">
+                  <Icon className="w-8 h-8" style={{ color, opacity: 0.3 }} />
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/client/src/components/shared/CardScreenshotCarousel.tsx
+++ b/client/src/components/shared/CardScreenshotCarousel.tsx
@@ -1,0 +1,55 @@
+/**
+ * CardScreenshotCarousel — compact real-screenshot crossfade for grid cards.
+ * No captions/arrows/dots (too small for chrome) — just an auto-advancing,
+ * uncropped rotation of real product screens at their native aspect ratio.
+ */
+import { useState, useEffect, useRef } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { DemoScreenshot } from '@/config/services';
+
+interface CardScreenshotCarouselProps {
+  slides: DemoScreenshot[];
+  serviceName: string;
+  intervalMs?: number;
+}
+
+export default function CardScreenshotCarousel({ slides, serviceName, intervalMs = 3500 }: CardScreenshotCarouselProps) {
+  const [index, setIndex] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (paused || slides.length <= 1) return;
+    timerRef.current = setInterval(() => {
+      setIndex(i => (i + 1) % slides.length);
+    }, intervalMs);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [paused, slides.length, intervalMs]);
+
+  if (slides.length === 0) return null;
+  const current = slides[index];
+
+  return (
+    <div
+      className="relative aspect-[2980/1556] w-full"
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+    >
+      <AnimatePresence mode="wait">
+        <motion.img
+          key={current.src}
+          src={current.src}
+          alt={`${serviceName} — ${current.caption}`}
+          className="absolute inset-0 w-full h-full object-contain"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.4, ease: 'easeInOut' }}
+          loading="lazy"
+        />
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/client/src/components/shared/ScreenshotCarousel.tsx
+++ b/client/src/components/shared/ScreenshotCarousel.tsx
@@ -52,13 +52,14 @@ export default function ScreenshotCarousel({ slides, serviceName, intervalMs = 5
       aria-roledescription="carousel"
       aria-label={`${serviceName} product screenshots`}
     >
-      <div className="relative aspect-[16/10] bg-[#080C16]">
+      {/* Frame matches the screenshots' native 2980:1556 ratio exactly — full image visible, no crop */}
+      <div className="relative aspect-[2980/1556] bg-[#080C16]">
         <AnimatePresence mode="wait">
           <motion.img
             key={current.src}
             src={current.src}
             alt={`${serviceName} — ${current.caption}`}
-            className="absolute inset-0 w-full h-full object-cover object-top"
+            className="absolute inset-0 w-full h-full object-contain"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -66,12 +67,6 @@ export default function ScreenshotCarousel({ slides, serviceName, intervalMs = 5
             loading={index === 0 ? 'eager' : 'lazy'}
           />
         </AnimatePresence>
-
-        {/* Caption bar */}
-        <div className="absolute bottom-0 left-0 right-0 px-4 sm:px-5 py-3 bg-gradient-to-t from-[#080C16] via-[#080C16]/90 to-transparent">
-          <p className="text-xs sm:text-sm text-white font-medium">{current.caption}</p>
-          <p className="text-[10px] text-[#596475] uppercase tracking-wider mt-0.5">Real product · live customer data</p>
-        </div>
 
         {/* Prev/next arrows — only when more than one slide */}
         {slides.length > 1 && (
@@ -94,6 +89,12 @@ export default function ScreenshotCarousel({ slides, serviceName, intervalMs = 5
             </button>
           </>
         )}
+      </div>
+
+      {/* Caption — below the frame, never overlapping the screenshot */}
+      <div className="px-4 sm:px-5 py-3 border-t border-[#1E2738]">
+        <p className="text-xs sm:text-sm text-white font-medium">{current.caption}</p>
+        <p className="text-[10px] text-[#596475] uppercase tracking-wider mt-0.5">Real product · live customer data</p>
       </div>
 
       {/* Dot indicators */}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -139,6 +139,7 @@ export default function Home() {
                 route={`/solutions/${service.slug}`}
                 status={service.status}
                 iconName={service.icon}
+                demoScreenshots={service.demoScreenshots}
               />
             ))}
           </StaggerContainer>
@@ -163,6 +164,7 @@ export default function Home() {
                 route={`/solutions/${service.slug}`}
                 status={service.status}
                 iconName={service.icon}
+                demoScreenshots={service.demoScreenshots}
               />
             ))}
           </StaggerContainer>


### PR DESCRIPTION
## Summary
- Fixes the screenshot carousel from #99: it was framed at `aspect-[16/10]` with `object-cover`, but every screenshot is actually `2980x1556` (~1.92:1) — narrower than the frame, so real content (Team Members panel, action rows, sidebar items) was getting cropped off. Frame now matches the screenshots' native ratio exactly with `object-contain`, so the whole image is always visible, and the caption moved below the frame instead of overlapping it.
- The homepage service grid (`AnimatedServiceCard`) was a separate, older component showing hardcoded fake mini-graphics — a randomly-jittering OEE gauge, a generic animated Kanban board, a single stale screenshot — not real product. It now shows the same real screenshots via a new compact `CardScreenshotCarousel`, for the five services that have them. Pre-launch services still fall back to their placeholder graphic.

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Verified in-browser: full screenshot visible with zero crop on Policy Deployment and SQDCP solution pages
- [x] Verified homepage grid renders real, uncropped screenshots for all 5 live services, no console errors
- [x] Confirmed pre-launch services (Safety/Quality/Certification Manager) still show their fallback graphic correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)